### PR TITLE
Create DRF file parser for race data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,83 @@
+import { useState, useCallback } from 'react'
 import { FileUpload } from './components/FileUpload'
+import type { ParsedDRFFile } from './types/drf'
 
 function App() {
+  const [parsedData, setParsedData] = useState<ParsedDRFFile | null>(null)
+
+  const handleParsed = useCallback((data: ParsedDRFFile) => {
+    setParsedData(data)
+  }, [])
+
+  const totalHorses = parsedData?.races.reduce((sum, race) => sum + race.horses.length, 0) ?? 0
+
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b border-white/10 px-6 py-4">
         <h1 className="text-xl font-semibold tracking-tight">Horse Monster</h1>
       </header>
       <main className="p-6">
-        <FileUpload />
+        <FileUpload onParsed={handleParsed} />
+
+        {parsedData && parsedData.races.length > 0 && (
+          <div className="mt-6 w-full max-w-xl">
+            <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+              <h2 className="text-sm font-medium text-white/60 uppercase tracking-wide mb-3">
+                Debug View
+              </h2>
+
+              <div className="space-y-2 text-sm">
+                <p>
+                  <span className="text-white/40">File:</span>{' '}
+                  <span className="text-foreground">{parsedData.filename}</span>
+                </p>
+                <p>
+                  <span className="text-white/40">Races:</span>{' '}
+                  <span className="text-foreground">{parsedData.races.length}</span>
+                </p>
+                <p>
+                  <span className="text-white/40">Total Horses:</span>{' '}
+                  <span className="text-foreground">{totalHorses}</span>
+                </p>
+              </div>
+
+              {parsedData.races.map((race, index) => (
+                <div key={index} className="mt-4 pt-4 border-t border-white/10">
+                  <div className="flex items-baseline gap-2 mb-2">
+                    <span className="text-foreground font-medium">
+                      {race.header.trackCode}
+                    </span>
+                    <span className="text-white/40">Race {race.header.raceNumber}</span>
+                    <span className="text-white/30 text-xs">
+                      {race.header.distance} | {race.header.surface} | {race.header.raceDate}
+                    </span>
+                  </div>
+
+                  <p className="text-xs text-white/40 mb-2">
+                    {race.horses.length} horse{race.horses.length !== 1 ? 's' : ''}
+                  </p>
+
+                  <ul className="space-y-1">
+                    {race.horses.map((horse, horseIndex) => (
+                      <li key={horseIndex} className="text-sm text-white/60">
+                        <span className="text-white/30 w-6 inline-block">
+                          {horse.postPosition}.
+                        </span>
+                        <span className="text-foreground">{horse.horseName}</span>
+                        <span className="text-white/30 ml-2">
+                          ({horse.jockeyName} / {horse.trainerName})
+                        </span>
+                        <span className="text-white/40 ml-2">
+                          ML: {horse.morningLineOdds}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </main>
     </div>
   )

--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,10 +1,83 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import type { DragEvent, ChangeEvent } from 'react'
+import type { ParsedDRFFile, DRFWorkerRequest, DRFWorkerResponse } from '../types/drf'
 
-export function FileUpload() {
+interface FileUploadProps {
+  onParsed?: (data: ParsedDRFFile) => void
+}
+
+export function FileUpload({ onParsed }: FileUploadProps) {
   const [fileName, setFileName] = useState<string | null>(null)
   const [isDragging, setIsDragging] = useState(false)
+  const [isParsing, setIsParsing] = useState(false)
+  const [parseStatus, setParseStatus] = useState<'idle' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const workerRef = useRef<Worker | null>(null)
+
+  useEffect(() => {
+    // Initialize the worker
+    workerRef.current = new Worker(
+      new URL('../lib/drfWorker.ts', import.meta.url),
+      { type: 'module' }
+    )
+
+    workerRef.current.onmessage = (event: MessageEvent<DRFWorkerResponse>) => {
+      setIsParsing(false)
+      const response = event.data
+
+      if (response.type === 'success' && response.data) {
+        setParseStatus('success')
+        setErrorMessage(null)
+        onParsed?.(response.data)
+      } else {
+        setParseStatus('error')
+        setErrorMessage(response.error || 'Failed to parse file')
+      }
+    }
+
+    workerRef.current.onerror = (error) => {
+      setIsParsing(false)
+      setParseStatus('error')
+      setErrorMessage(error.message || 'Worker error')
+    }
+
+    return () => {
+      workerRef.current?.terminate()
+    }
+  }, [onParsed])
+
+  const processFile = (file: File) => {
+    if (!file.name.endsWith('.drf')) {
+      setParseStatus('error')
+      setErrorMessage('Only .drf files are accepted')
+      return
+    }
+
+    setFileName(file.name)
+    setIsParsing(true)
+    setParseStatus('idle')
+    setErrorMessage(null)
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const content = e.target?.result as string
+      if (workerRef.current && content) {
+        const request: DRFWorkerRequest = {
+          type: 'parse',
+          fileContent: content,
+          filename: file.name,
+        }
+        workerRef.current.postMessage(request)
+      }
+    }
+    reader.onerror = () => {
+      setIsParsing(false)
+      setParseStatus('error')
+      setErrorMessage('Failed to read file')
+    }
+    reader.readAsText(file)
+  }
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault()
@@ -21,15 +94,15 @@ export function FileUpload() {
     setIsDragging(false)
 
     const file = e.dataTransfer.files[0]
-    if (file && file.name.endsWith('.drf')) {
-      setFileName(file.name)
+    if (file) {
+      processFile(file)
     }
   }
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
-      setFileName(file.name)
+      processFile(file)
     }
   }
 
@@ -62,22 +135,87 @@ export function FileUpload() {
 
         <div className="flex flex-col items-center gap-4">
           <div className="rounded-full bg-white/5 p-3">
-            <svg
-              className="h-6 w-6 text-white/40"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={1.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-              />
-            </svg>
+            {isParsing ? (
+              <svg
+                className="h-6 w-6 text-white/40 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                />
+              </svg>
+            ) : parseStatus === 'success' ? (
+              <svg
+                className="h-6 w-6 text-green-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            ) : parseStatus === 'error' ? (
+              <svg
+                className="h-6 w-6 text-red-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            ) : (
+              <svg
+                className="h-6 w-6 text-white/40"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
+                />
+              </svg>
+            )}
           </div>
 
-          {fileName ? (
+          {isParsing ? (
+            <div className="text-center">
+              <p className="text-sm font-medium text-foreground">Parsing...</p>
+              <p className="mt-1 text-xs text-white/40">{fileName}</p>
+            </div>
+          ) : parseStatus === 'success' ? (
+            <div className="text-center">
+              <p className="text-sm font-medium text-green-400">File parsed successfully</p>
+              <p className="mt-1 text-xs text-white/40">{fileName}</p>
+            </div>
+          ) : parseStatus === 'error' ? (
+            <div className="text-center">
+              <p className="text-sm font-medium text-red-400">Parse failed</p>
+              <p className="mt-1 text-xs text-white/40">{errorMessage}</p>
+            </div>
+          ) : fileName ? (
             <div className="text-center">
               <p className="text-sm font-medium text-foreground">{fileName}</p>
               <p className="mt-1 text-xs text-white/40">Ready to process</p>
@@ -92,16 +230,18 @@ export function FileUpload() {
 
           <button
             onClick={handleButtonClick}
+            disabled={isParsing}
             className="
               rounded-md bg-white/10 px-4 py-2 text-sm font-medium
               text-foreground transition-all duration-150
               hover:bg-white/15 active:scale-[0.98]
+              disabled:opacity-50 disabled:cursor-not-allowed
             "
           >
-            Upload DRF File
+            {isParsing ? 'Parsing...' : 'Upload DRF File'}
           </button>
 
-          {!fileName && (
+          {!fileName && !isParsing && parseStatus === 'idle' && (
             <p className="text-xs text-white/30">
               Only .drf files are accepted
             </p>

--- a/src/lib/drfParser.ts
+++ b/src/lib/drfParser.ts
@@ -1,0 +1,210 @@
+import type { HorseEntry, ParsedRace, ParsedDRFFile } from '../types/drf'
+
+/**
+ * DRF files are fixed-width text format from Daily Racing Form.
+ * Each line represents either race header info or horse entry data.
+ *
+ * Typical DRF structure:
+ * - Lines are comma-delimited or fixed-width
+ * - First field typically contains track code (3 chars)
+ * - Race data followed by horse entries
+ */
+
+// Column positions for DRF fixed-width format (approximate - may need adjustment)
+const COLUMNS = {
+  TRACK_CODE: { start: 0, end: 3 },
+  RACE_DATE: { start: 3, end: 11 },
+  RACE_NUMBER: { start: 11, end: 13 },
+  DISTANCE: { start: 13, end: 18 },
+  SURFACE: { start: 18, end: 19 },
+  // Horse entry columns
+  PROGRAM_NUMBER: { start: 0, end: 3 },
+  HORSE_NAME: { start: 3, end: 28 },
+  JOCKEY_NAME: { start: 28, end: 53 },
+  TRAINER_NAME: { start: 53, end: 78 },
+  MORNING_LINE: { start: 78, end: 85 },
+  POST_POSITION: { start: 85, end: 88 },
+}
+
+function parseSurface(code: string): 'dirt' | 'turf' | 'synthetic' {
+  const normalized = code.trim().toUpperCase()
+  if (normalized === 'T' || normalized === 'TURF') return 'turf'
+  if (normalized === 'S' || normalized === 'SYN' || normalized === 'A') return 'synthetic'
+  return 'dirt' // D or default
+}
+
+function parseDistance(raw: string): string {
+  const trimmed = raw.trim()
+  // Convert numeric furlongs to readable format
+  const furlongs = parseFloat(trimmed)
+  if (!isNaN(furlongs)) {
+    if (furlongs >= 8) {
+      const miles = furlongs / 8
+      return `${miles.toFixed(miles % 1 === 0 ? 0 : 2)} mile${miles !== 1 ? 's' : ''}`
+    }
+    return `${furlongs}f`
+  }
+  return trimmed || 'Unknown'
+}
+
+function extractField(line: string, start: number, end: number): string {
+  return line.substring(start, Math.min(end, line.length)).trim()
+}
+
+function parseCSVLine(line: string): string[] {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (const char of line) {
+    if (char === '"') {
+      inQuotes = !inQuotes
+    } else if (char === ',' && !inQuotes) {
+      fields.push(current.trim())
+      current = ''
+    } else {
+      current += char
+    }
+  }
+  fields.push(current.trim())
+
+  return fields
+}
+
+function parseHorseEntry(fields: string[], lineIndex: number): HorseEntry {
+  // DRF files typically have many fields per horse
+  // Common field positions (may vary by DRF version):
+  // 0: Track code
+  // 1: Date
+  // 2: Race number
+  // 3: Post position
+  // 4: Entry indicator
+  // 5: Horse name
+  // 6-7: Jockey name (last, first)
+  // 8-9: Trainer name (last, first)
+  // Plus many more fields for past performances
+
+  const postPosition = parseInt(fields[3] || String(lineIndex + 1), 10) || lineIndex + 1
+  const programNumber = parseInt(fields[4] || fields[3] || String(lineIndex + 1), 10) || lineIndex + 1
+  const horseName = fields[5] || fields[4] || `Horse ${lineIndex + 1}`
+
+  // Jockey name - often split into last, first
+  const jockeyLast = fields[6] || ''
+  const jockeyFirst = fields[7] || ''
+  const jockeyName = jockeyFirst ? `${jockeyFirst} ${jockeyLast}`.trim() : jockeyLast
+
+  // Trainer name - often split into last, first
+  const trainerLast = fields[8] || ''
+  const trainerFirst = fields[9] || ''
+  const trainerName = trainerFirst ? `${trainerFirst} ${trainerLast}`.trim() : trainerLast
+
+  // Morning line odds - typically found later in the line
+  // Look for a field that looks like odds (e.g., "5-1", "3-2", "8")
+  let morningLineOdds = '0-0'
+  for (let i = 10; i < Math.min(fields.length, 30); i++) {
+    const field = fields[i]
+    if (field && /^\d+(-\d+)?$/.test(field)) {
+      morningLineOdds = field.includes('-') ? field : `${field}-1`
+      break
+    }
+  }
+
+  return {
+    programNumber,
+    horseName,
+    jockeyName: jockeyName || 'Unknown',
+    trainerName: trainerName || 'Unknown',
+    morningLineOdds,
+    postPosition,
+  }
+}
+
+/**
+ * Parse a DRF file content string into structured data.
+ * Handles both comma-delimited and fixed-width formats.
+ */
+export function parseDRFFile(content: string, filename: string): ParsedDRFFile {
+  const lines = content.split(/\r?\n/).filter(line => line.trim().length > 0)
+
+  if (lines.length === 0) {
+    return { filename, races: [] }
+  }
+
+  // Detect format: CSV (has commas) or fixed-width
+  const isCSV = lines[0].includes(',')
+
+  const racesMap = new Map<string, ParsedRace>()
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    if (isCSV) {
+      const fields = parseCSVLine(line)
+      if (fields.length < 5) continue
+
+      // Extract race key from track code, date, and race number
+      const trackCode = fields[0]?.substring(0, 3) || 'UNK'
+      const raceDate = fields[1] || ''
+      const raceNumber = parseInt(fields[2] || '0', 10)
+      const raceKey = `${trackCode}-${raceDate}-${raceNumber}`
+
+      if (!racesMap.has(raceKey)) {
+        racesMap.set(raceKey, {
+          header: {
+            trackCode,
+            raceDate,
+            raceNumber: raceNumber || 1,
+            distance: parseDistance(fields[3] || ''),
+            surface: parseSurface(fields[4] || 'D'),
+          },
+          horses: [],
+        })
+      }
+
+      // Parse horse entry if we have enough fields
+      if (fields.length >= 6) {
+        const race = racesMap.get(raceKey)!
+        const horseEntry = parseHorseEntry(fields, race.horses.length)
+        race.horses.push(horseEntry)
+      }
+    } else {
+      // Fixed-width format parsing
+      if (line.length < 20) continue
+
+      const trackCode = extractField(line, COLUMNS.TRACK_CODE.start, COLUMNS.TRACK_CODE.end)
+      const raceDate = extractField(line, COLUMNS.RACE_DATE.start, COLUMNS.RACE_DATE.end)
+      const raceNumber = parseInt(extractField(line, COLUMNS.RACE_NUMBER.start, COLUMNS.RACE_NUMBER.end), 10) || 1
+      const raceKey = `${trackCode}-${raceDate}-${raceNumber}`
+
+      if (!racesMap.has(raceKey)) {
+        racesMap.set(raceKey, {
+          header: {
+            trackCode,
+            raceDate,
+            raceNumber,
+            distance: parseDistance(extractField(line, COLUMNS.DISTANCE.start, COLUMNS.DISTANCE.end)),
+            surface: parseSurface(extractField(line, COLUMNS.SURFACE.start, COLUMNS.SURFACE.end)),
+          },
+          horses: [],
+        })
+      }
+
+      // For fixed-width, each line is typically a horse entry
+      const race = racesMap.get(raceKey)!
+      const horseEntry: HorseEntry = {
+        programNumber: parseInt(extractField(line, COLUMNS.PROGRAM_NUMBER.start, COLUMNS.PROGRAM_NUMBER.end), 10) || race.horses.length + 1,
+        horseName: extractField(line, COLUMNS.HORSE_NAME.start, COLUMNS.HORSE_NAME.end) || `Horse ${race.horses.length + 1}`,
+        jockeyName: extractField(line, COLUMNS.JOCKEY_NAME.start, COLUMNS.JOCKEY_NAME.end) || 'Unknown',
+        trainerName: extractField(line, COLUMNS.TRAINER_NAME.start, COLUMNS.TRAINER_NAME.end) || 'Unknown',
+        morningLineOdds: extractField(line, COLUMNS.MORNING_LINE.start, COLUMNS.MORNING_LINE.end) || '0-0',
+        postPosition: parseInt(extractField(line, COLUMNS.POST_POSITION.start, COLUMNS.POST_POSITION.end), 10) || race.horses.length + 1,
+      }
+      race.horses.push(horseEntry)
+    }
+  }
+
+  // Convert map to array and sort by race number
+  const races = Array.from(racesMap.values()).sort((a, b) => a.header.raceNumber - b.header.raceNumber)
+
+  return { filename, races }
+}

--- a/src/lib/drfWorker.ts
+++ b/src/lib/drfWorker.ts
@@ -1,0 +1,28 @@
+import { parseDRFFile } from './drfParser'
+import type { DRFWorkerRequest, DRFWorkerResponse } from '../types/drf'
+
+/**
+ * Web Worker for parsing DRF files.
+ * Offloads parsing to a background thread to avoid blocking the UI.
+ */
+
+self.onmessage = (event: MessageEvent<DRFWorkerRequest>) => {
+  const { type, fileContent, filename } = event.data
+
+  if (type === 'parse') {
+    try {
+      const result = parseDRFFile(fileContent, filename)
+      const response: DRFWorkerResponse = {
+        type: 'success',
+        data: result,
+      }
+      self.postMessage(response)
+    } catch (error) {
+      const response: DRFWorkerResponse = {
+        type: 'error',
+        error: error instanceof Error ? error.message : 'Unknown parsing error',
+      }
+      self.postMessage(response)
+    }
+  }
+}

--- a/src/types/drf.ts
+++ b/src/types/drf.ts
@@ -1,3 +1,44 @@
+export interface RaceHeader {
+  trackCode: string
+  raceNumber: number
+  distance: string
+  surface: 'dirt' | 'turf' | 'synthetic'
+  raceDate: string
+}
+
+export interface HorseEntry {
+  programNumber: number
+  horseName: string
+  trainerName: string
+  jockeyName: string
+  morningLineOdds: string
+  postPosition: number
+}
+
+export interface ParsedRace {
+  header: RaceHeader
+  horses: HorseEntry[]
+}
+
+export interface ParsedDRFFile {
+  filename: string
+  races: ParsedRace[]
+}
+
+// Worker message types
+export interface DRFWorkerRequest {
+  type: 'parse'
+  fileContent: string
+  filename: string
+}
+
+export interface DRFWorkerResponse {
+  type: 'success' | 'error'
+  data?: ParsedDRFFile
+  error?: string
+}
+
+// Legacy interfaces for backwards compatibility
 export interface Race {
   track: string
   date: string


### PR DESCRIPTION
- Create drfParser.ts with parsing logic for DRF fixed-width and CSV formats
- Parse race headers (track code, race number, distance, surface, date)
- Parse horse entries (program number, name, trainer, jockey, odds, post position)
- Add drfWorker.ts to offload parsing to background thread
- Update FileUpload.tsx with worker integration and loading states
- Add debug view in App.tsx showing parsed race and horse data
- Expand TypeScript interfaces in drf.ts for parsed data structures