### PR TITLE
Create race data table with Material Design

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Horse Monster</title>
+    <!-- Google Fonts: Inter -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Google Material Icons -->
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
 import { FileUpload } from './components/FileUpload'
+import { RaceTable } from './components/RaceTable'
 import type { ParsedDRFFile } from './types/drf'
 
 function App() {
@@ -20,60 +21,24 @@ function App() {
         <FileUpload onParsed={handleParsed} />
 
         {parsedData && parsedData.races.length > 0 && (
-          <div className="mt-6 w-full max-w-xl">
-            <div className="rounded-lg border border-white/10 bg-white/5 p-4">
-              <h2 className="text-sm font-medium text-white/60 uppercase tracking-wide mb-3">
-                Debug View
-              </h2>
+          <div className="mt-6">
+            {/* Summary stats */}
+            <div className="mb-6 flex flex-wrap items-center gap-4 text-sm text-white/60">
+              <span>
+                <span className="text-foreground font-medium">{parsedData.races.length}</span> race{parsedData.races.length !== 1 ? 's' : ''}
+              </span>
+              <span className="text-white/20">•</span>
+              <span>
+                <span className="text-foreground font-medium">{totalHorses}</span> horse{totalHorses !== 1 ? 's' : ''}
+              </span>
+              <span className="text-white/20">•</span>
+              <span className="text-white/40">{parsedData.filename}</span>
+            </div>
 
-              <div className="space-y-2 text-sm">
-                <p>
-                  <span className="text-white/40">File:</span>{' '}
-                  <span className="text-foreground">{parsedData.filename}</span>
-                </p>
-                <p>
-                  <span className="text-white/40">Races:</span>{' '}
-                  <span className="text-foreground">{parsedData.races.length}</span>
-                </p>
-                <p>
-                  <span className="text-white/40">Total Horses:</span>{' '}
-                  <span className="text-foreground">{totalHorses}</span>
-                </p>
-              </div>
-
+            {/* Race tables */}
+            <div className="space-y-6">
               {parsedData.races.map((race, index) => (
-                <div key={index} className="mt-4 pt-4 border-t border-white/10">
-                  <div className="flex items-baseline gap-2 mb-2">
-                    <span className="text-foreground font-medium">
-                      {race.header.trackCode}
-                    </span>
-                    <span className="text-white/40">Race {race.header.raceNumber}</span>
-                    <span className="text-white/30 text-xs">
-                      {race.header.distance} | {race.header.surface} | {race.header.raceDate}
-                    </span>
-                  </div>
-
-                  <p className="text-xs text-white/40 mb-2">
-                    {race.horses.length} horse{race.horses.length !== 1 ? 's' : ''}
-                  </p>
-
-                  <ul className="space-y-1">
-                    {race.horses.map((horse, horseIndex) => (
-                      <li key={horseIndex} className="text-sm text-white/60">
-                        <span className="text-white/30 w-6 inline-block">
-                          {horse.postPosition}.
-                        </span>
-                        <span className="text-foreground">{horse.horseName}</span>
-                        <span className="text-white/30 ml-2">
-                          ({horse.jockeyName} / {horse.trainerName})
-                        </span>
-                        <span className="text-white/40 ml-2">
-                          ML: {horse.morningLineOdds}
-                        </span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+                <RaceTable key={index} race={race} />
               ))}
             </div>
           </div>

--- a/src/components/RaceTable.tsx
+++ b/src/components/RaceTable.tsx
@@ -1,0 +1,134 @@
+import type { ParsedRace } from '../types/drf'
+
+interface RaceTableProps {
+  race: ParsedRace
+}
+
+// Material Icon component for cleaner usage
+function Icon({ name, className = '' }: { name: string; className?: string }) {
+  return (
+    <span className={`material-icons ${className}`} aria-hidden="true">
+      {name}
+    </span>
+  )
+}
+
+// Race header card component
+function RaceHeader({ race }: { race: ParsedRace }) {
+  const { header } = race
+
+  // Format surface for display
+  const surfaceLabel = header.surface.charAt(0).toUpperCase() + header.surface.slice(1)
+
+  return (
+    <div className="race-header-card">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="track-badge">
+            <Icon name="location_on" className="text-lg" />
+            <span className="font-semibold">{header.trackCode}</span>
+          </div>
+          <div className="race-number">
+            Race {header.raceNumber}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4 text-sm">
+          <div className="info-chip">
+            <Icon name="route" className="text-base" />
+            <span>{header.distance}</span>
+          </div>
+          <div className="info-chip">
+            <Icon name="terrain" className="text-base" />
+            <span>{surfaceLabel}</span>
+          </div>
+          <div className="text-white/40 text-xs">
+            {header.raceDate}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Main RaceTable component
+export function RaceTable({ race }: RaceTableProps) {
+  const { horses } = race
+
+  return (
+    <div className="race-table-container">
+      <RaceHeader race={race} />
+
+      {/* Desktop/Tablet Table View */}
+      <div className="hidden sm:block overflow-x-auto">
+        <table className="race-table">
+          <thead>
+            <tr>
+              <th className="w-16 text-center">PP</th>
+              <th className="text-left">Horse</th>
+              <th className="text-left">Trainer</th>
+              <th className="text-left">Jockey</th>
+              <th className="w-24 text-right">ML Odds</th>
+            </tr>
+          </thead>
+          <tbody>
+            {horses.map((horse, index) => (
+              <tr key={index} className="race-row">
+                <td className="text-center tabular-nums font-medium">
+                  {horse.postPosition}
+                </td>
+                <td className="font-medium text-foreground">
+                  {horse.horseName}
+                </td>
+                <td className="text-white/70">
+                  {horse.trainerName}
+                </td>
+                <td className="text-white/70">
+                  {horse.jockeyName}
+                </td>
+                <td className="text-right tabular-nums text-accent font-medium">
+                  {horse.morningLineOdds}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile Card View */}
+      <div className="sm:hidden space-y-2">
+        {horses.map((horse, index) => (
+          <div key={index} className="mobile-horse-card">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <div className="pp-badge">
+                  {horse.postPosition}
+                </div>
+                <div>
+                  <div className="font-medium text-foreground">
+                    {horse.horseName}
+                  </div>
+                  <div className="text-xs text-white/50 mt-0.5">
+                    {horse.jockeyName}
+                  </div>
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-accent font-medium tabular-nums">
+                  {horse.morningLineOdds}
+                </div>
+                <div className="text-xs text-white/40">ML</div>
+              </div>
+            </div>
+            <div className="mt-2 pt-2 border-t border-white/5 text-xs text-white/50">
+              <span className="text-white/30">T:</span> {horse.trainerName}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// Styles embedded as CSS-in-JS alternative using Tailwind @apply
+// These styles are defined in index.css

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
 }
 
 :root {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -18,4 +18,135 @@ body {
   min-height: 100vh;
   background-color: var(--color-background);
   color: var(--color-foreground);
+}
+
+/* Material Design 3 Custom Properties */
+:root {
+  --color-primary: #19abb5;
+  --color-primary-hover: #1b7583;
+  --color-surface: #1a1a1c;
+  --color-surface-variant: #242428;
+  --color-on-surface: #EEEFF1;
+  --color-on-surface-variant: rgba(238, 239, 241, 0.7);
+  --color-outline: rgba(255, 255, 255, 0.1);
+}
+
+/* Race Table Container */
+.race-table-container {
+  width: 100%;
+  max-width: 1200px;
+  margin-bottom: 1.5rem;
+}
+
+/* Race Header Card - MD3 Surface styling */
+.race-header-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Track Badge */
+.track-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+/* Race Number */
+.race-number {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-on-surface);
+}
+
+/* Info Chips */
+.info-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: var(--color-on-surface-variant);
+  background-color: var(--color-surface-variant);
+  padding: 0.25rem 0.75rem;
+  border-radius: 8px;
+}
+
+/* Race Table */
+.race-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.race-table thead {
+  background-color: var(--color-surface-variant);
+}
+
+.race-table th {
+  padding: 0.875rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(238, 239, 241, 0.5);
+  border-bottom: 1px solid var(--color-outline);
+}
+
+.race-table td {
+  padding: 0.875rem 1rem;
+  font-size: 0.875rem;
+  border-bottom: 1px solid var(--color-outline);
+}
+
+.race-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Row hover effect */
+.race-row {
+  transition: background-color 0.15s ease;
+}
+
+.race-row:hover {
+  background-color: var(--color-primary-hover);
+}
+
+/* Accent color for odds */
+.text-accent {
+  color: var(--color-primary);
+}
+
+/* Tabular numbers for consistent alignment */
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+}
+
+/* Mobile Horse Card */
+.mobile-horse-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  padding: 0.875rem 1rem;
+}
+
+/* Post Position Badge */
+.pp-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background-color: var(--color-surface-variant);
+  border-radius: 8px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-on-surface);
+  flex-shrink: 0;
 }


### PR DESCRIPTION
- Create RaceTable component displaying parsed race data in a clean table
- Add race header card showing track, race number, distance, and surface
- Use Inter font from Google Fonts for typography
- Add Google Material Icons for track, route, and terrain indicators
- Implement dark theme with primary accent color (#19abb5)
- Add responsive design with mobile card view for smaller screens
- Include hover effects on table rows
- Use tabular numbers for post position and odds columns
- Replace debug view with clean table layout in App.tsx