### PR TITLE
Add manual controls for real-time race adjustments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,18 @@
 import { useState, useCallback } from 'react'
 import { FileUpload } from './components/FileUpload'
 import { RaceTable } from './components/RaceTable'
+import { useRaceState } from './hooks/useRaceState'
 import type { ParsedDRFFile } from './types/drf'
 
 function App() {
   const [parsedData, setParsedData] = useState<ParsedDRFFile | null>(null)
+  const raceState = useRaceState()
 
   const handleParsed = useCallback((data: ParsedDRFFile) => {
     setParsedData(data)
-  }, [])
+    // Reset race state when new file is loaded
+    raceState.resetAll()
+  }, [raceState])
 
   const totalHorses = parsedData?.races.reduce((sum, race) => sum + race.horses.length, 0) ?? 0
 
@@ -38,7 +42,7 @@ function App() {
             {/* Race tables */}
             <div className="space-y-6">
               {parsedData.races.map((race, index) => (
-                <RaceTable key={index} race={race} />
+                <RaceTable key={index} race={race} raceState={raceState} />
               ))}
             </div>
           </div>

--- a/src/components/RaceControls.tsx
+++ b/src/components/RaceControls.tsx
@@ -1,0 +1,56 @@
+import { TRACK_CONDITIONS, type TrackCondition } from '../hooks/useRaceState'
+
+interface RaceControlsProps {
+  trackCondition: TrackCondition
+  onTrackConditionChange: (condition: TrackCondition) => void
+  surface?: 'dirt' | 'turf' | 'synthetic'
+}
+
+// Material Icon component
+function Icon({ name, className = '' }: { name: string; className?: string }) {
+  return (
+    <span className={`material-icons ${className}`} aria-hidden="true">
+      {name}
+    </span>
+  )
+}
+
+export function RaceControls({
+  trackCondition,
+  onTrackConditionChange,
+  surface = 'dirt',
+}: RaceControlsProps) {
+  // Filter conditions based on surface
+  const availableConditions = TRACK_CONDITIONS.filter(
+    (condition) =>
+      condition.surface === 'both' ||
+      condition.surface === surface ||
+      (surface === 'synthetic' && condition.surface === 'dirt')
+  )
+
+  return (
+    <div className="race-controls">
+      <div className="race-controls-section">
+        <label className="race-controls-label" htmlFor="track-condition">
+          <Icon name="wb_cloudy" className="race-controls-icon" />
+          <span>Track Condition</span>
+        </label>
+        <div className="select-wrapper">
+          <select
+            id="track-condition"
+            className="race-select"
+            value={trackCondition}
+            onChange={(e) => onTrackConditionChange(e.target.value as TrackCondition)}
+          >
+            {availableConditions.map((condition) => (
+              <option key={condition.value} value={condition.value}>
+                {condition.label}
+              </option>
+            ))}
+          </select>
+          <Icon name="expand_more" className="select-chevron" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/RaceTable.tsx
+++ b/src/components/RaceTable.tsx
@@ -1,7 +1,11 @@
+import { useState, useCallback } from 'react'
 import type { ParsedRace } from '../types/drf'
+import type { TrackCondition, UseRaceStateReturn } from '../hooks/useRaceState'
+import { RaceControls } from './RaceControls'
 
 interface RaceTableProps {
   race: ParsedRace
+  raceState: UseRaceStateReturn
 }
 
 // Material Icon component for cleaner usage
@@ -13,8 +17,101 @@ function Icon({ name, className = '' }: { name: string; className?: string }) {
   )
 }
 
+// Editable odds field component
+interface EditableOddsProps {
+  value: string
+  onChange: (value: string) => void
+  hasChanged: boolean
+  disabled?: boolean
+}
+
+function EditableOdds({ value, onChange, hasChanged, disabled }: EditableOddsProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editValue, setEditValue] = useState(value)
+
+  const handleClick = useCallback(() => {
+    if (!disabled) {
+      setEditValue(value)
+      setIsEditing(true)
+    }
+  }, [disabled, value])
+
+  const handleBlur = useCallback(() => {
+    setIsEditing(false)
+    if (editValue.trim() && editValue !== value) {
+      onChange(editValue.trim())
+    }
+  }, [editValue, value, onChange])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur()
+    } else if (e.key === 'Escape') {
+      setEditValue(value)
+      setIsEditing(false)
+    }
+  }, [value])
+
+  if (isEditing) {
+    return (
+      <input
+        type="text"
+        className="odds-input"
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onBlur={handleBlur}
+        onKeyDown={handleKeyDown}
+        autoFocus
+      />
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className={`odds-display ${hasChanged ? 'odds-changed' : ''} ${disabled ? 'odds-disabled' : ''}`}
+      onClick={handleClick}
+      disabled={disabled}
+    >
+      <span className="tabular-nums">{value}</span>
+      {!disabled && <Icon name="edit" className="odds-edit-icon" />}
+    </button>
+  )
+}
+
+// Scratch checkbox component
+interface ScratchCheckboxProps {
+  checked: boolean
+  onChange: () => void
+  horseName: string
+}
+
+function ScratchCheckbox({ checked, onChange, horseName }: ScratchCheckboxProps) {
+  return (
+    <label className="scratch-checkbox" title={checked ? `Unscratsch ${horseName}` : `Scratch ${horseName}`}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className="scratch-input"
+      />
+      <span className="scratch-box">
+        <Icon name={checked ? 'close' : 'check_box_outline_blank'} className="scratch-icon" />
+      </span>
+    </label>
+  )
+}
+
 // Race header card component
-function RaceHeader({ race }: { race: ParsedRace }) {
+function RaceHeader({
+  race,
+  trackCondition,
+  onTrackConditionChange,
+}: {
+  race: ParsedRace
+  trackCondition: TrackCondition
+  onTrackConditionChange: (condition: TrackCondition) => void
+}) {
   const { header } = race
 
   // Format surface for display
@@ -22,113 +119,173 @@ function RaceHeader({ race }: { race: ParsedRace }) {
 
   return (
     <div className="race-header-card">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex items-center gap-3">
-          <div className="track-badge">
-            <Icon name="location_on" className="text-lg" />
-            <span className="font-semibold">{header.trackCode}</span>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="track-badge">
+              <Icon name="location_on" className="text-lg" />
+              <span className="font-semibold">{header.trackCode}</span>
+            </div>
+            <div className="race-number">
+              Race {header.raceNumber}
+            </div>
           </div>
-          <div className="race-number">
-            Race {header.raceNumber}
+
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <div className="info-chip">
+              <Icon name="route" className="text-base" />
+              <span>{header.distance}</span>
+            </div>
+            <div className="info-chip">
+              <Icon name="terrain" className="text-base" />
+              <span>{surfaceLabel}</span>
+            </div>
+            <div className="text-white/40 text-xs">
+              {header.raceDate}
+            </div>
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-4 text-sm">
-          <div className="info-chip">
-            <Icon name="route" className="text-base" />
-            <span>{header.distance}</span>
-          </div>
-          <div className="info-chip">
-            <Icon name="terrain" className="text-base" />
-            <span>{surfaceLabel}</span>
-          </div>
-          <div className="text-white/40 text-xs">
-            {header.raceDate}
-          </div>
-        </div>
+        {/* Race Controls integrated in header */}
+        <RaceControls
+          trackCondition={trackCondition}
+          onTrackConditionChange={onTrackConditionChange}
+          surface={header.surface}
+        />
       </div>
     </div>
   )
 }
 
 // Main RaceTable component
-export function RaceTable({ race }: RaceTableProps) {
+export function RaceTable({ race, raceState }: RaceTableProps) {
   const { horses } = race
+  const {
+    trackCondition,
+    setTrackCondition,
+    toggleScratch,
+    isScratched,
+    getOdds,
+    updateOdds,
+    hasOddsChanged,
+  } = raceState
 
   return (
     <div className="race-table-container">
-      <RaceHeader race={race} />
+      <RaceHeader
+        race={race}
+        trackCondition={trackCondition}
+        onTrackConditionChange={setTrackCondition}
+      />
 
       {/* Desktop/Tablet Table View */}
       <div className="hidden sm:block overflow-x-auto">
         <table className="race-table">
           <thead>
             <tr>
+              <th className="w-12 text-center">
+                <Icon name="cancel" className="text-base text-white/40" />
+              </th>
               <th className="w-16 text-center">PP</th>
               <th className="text-left">Horse</th>
               <th className="text-left">Trainer</th>
               <th className="text-left">Jockey</th>
-              <th className="w-24 text-right">ML Odds</th>
+              <th className="w-28 text-right">Odds</th>
             </tr>
           </thead>
           <tbody>
-            {horses.map((horse, index) => (
-              <tr key={index} className="race-row">
-                <td className="text-center tabular-nums font-medium">
-                  {horse.postPosition}
-                </td>
-                <td className="font-medium text-foreground">
-                  {horse.horseName}
-                </td>
-                <td className="text-white/70">
-                  {horse.trainerName}
-                </td>
-                <td className="text-white/70">
-                  {horse.jockeyName}
-                </td>
-                <td className="text-right tabular-nums text-accent font-medium">
-                  {horse.morningLineOdds}
-                </td>
-              </tr>
-            ))}
+            {horses.map((horse, index) => {
+              const scratched = isScratched(index)
+              const currentOdds = getOdds(index, horse.morningLineOdds)
+              const oddsChanged = hasOddsChanged(index)
+
+              return (
+                <tr
+                  key={index}
+                  className={`race-row ${scratched ? 'race-row-scratched' : ''}`}
+                >
+                  <td className="text-center">
+                    <ScratchCheckbox
+                      checked={scratched}
+                      onChange={() => toggleScratch(index)}
+                      horseName={horse.horseName}
+                    />
+                  </td>
+                  <td className="text-center tabular-nums font-medium">
+                    {horse.postPosition}
+                  </td>
+                  <td className={`font-medium ${scratched ? 'horse-name-scratched' : 'text-foreground'}`}>
+                    {horse.horseName}
+                  </td>
+                  <td className="text-white/70">
+                    {horse.trainerName}
+                  </td>
+                  <td className="text-white/70">
+                    {horse.jockeyName}
+                  </td>
+                  <td className="text-right">
+                    <EditableOdds
+                      value={currentOdds}
+                      onChange={(newOdds) => updateOdds(index, newOdds)}
+                      hasChanged={oddsChanged}
+                      disabled={scratched}
+                    />
+                  </td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </div>
 
       {/* Mobile Card View */}
       <div className="sm:hidden space-y-2">
-        {horses.map((horse, index) => (
-          <div key={index} className="mobile-horse-card">
-            <div className="flex items-start justify-between gap-3">
-              <div className="flex items-center gap-3">
-                <div className="pp-badge">
-                  {horse.postPosition}
+        {horses.map((horse, index) => {
+          const scratched = isScratched(index)
+          const currentOdds = getOdds(index, horse.morningLineOdds)
+          const oddsChanged = hasOddsChanged(index)
+
+          return (
+            <div
+              key={index}
+              className={`mobile-horse-card ${scratched ? 'mobile-card-scratched' : ''}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-center gap-3">
+                  <ScratchCheckbox
+                    checked={scratched}
+                    onChange={() => toggleScratch(index)}
+                    horseName={horse.horseName}
+                  />
+                  <div className="pp-badge">
+                    {horse.postPosition}
+                  </div>
+                  <div>
+                    <div className={`font-medium ${scratched ? 'horse-name-scratched' : 'text-foreground'}`}>
+                      {horse.horseName}
+                    </div>
+                    <div className="text-xs text-white/50 mt-0.5">
+                      {horse.jockeyName}
+                    </div>
+                  </div>
                 </div>
-                <div>
-                  <div className="font-medium text-foreground">
-                    {horse.horseName}
-                  </div>
-                  <div className="text-xs text-white/50 mt-0.5">
-                    {horse.jockeyName}
-                  </div>
+                <div className="text-right">
+                  <EditableOdds
+                    value={currentOdds}
+                    onChange={(newOdds) => updateOdds(index, newOdds)}
+                    hasChanged={oddsChanged}
+                    disabled={scratched}
+                  />
+                  <div className="text-xs text-white/40">Odds</div>
                 </div>
               </div>
-              <div className="text-right">
-                <div className="text-accent font-medium tabular-nums">
-                  {horse.morningLineOdds}
-                </div>
-                <div className="text-xs text-white/40">ML</div>
+              <div className="mt-2 pt-2 border-t border-white/5 text-xs text-white/50">
+                <span className="text-white/30">T:</span> {horse.trainerName}
               </div>
             </div>
-            <div className="mt-2 pt-2 border-t border-white/5 text-xs text-white/50">
-              <span className="text-white/30">T:</span> {horse.trainerName}
-            </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )
 }
-
-// Styles embedded as CSS-in-JS alternative using Tailwind @apply
-// These styles are defined in index.css

--- a/src/hooks/useRaceState.ts
+++ b/src/hooks/useRaceState.ts
@@ -1,0 +1,156 @@
+import { useState, useCallback, useMemo } from 'react'
+
+// Track condition options
+export type TrackCondition =
+  | 'fast'
+  | 'good'
+  | 'muddy'
+  | 'sloppy'
+  | 'yielding'
+  | 'firm'
+
+export interface TrackConditionOption {
+  value: TrackCondition
+  label: string
+  surface: 'dirt' | 'turf' | 'both'
+}
+
+export const TRACK_CONDITIONS: TrackConditionOption[] = [
+  { value: 'fast', label: 'Fast', surface: 'dirt' },
+  { value: 'good', label: 'Good', surface: 'both' },
+  { value: 'muddy', label: 'Muddy', surface: 'dirt' },
+  { value: 'sloppy', label: 'Sloppy', surface: 'dirt' },
+  { value: 'yielding', label: 'Yielding (Turf)', surface: 'turf' },
+  { value: 'firm', label: 'Firm (Turf)', surface: 'turf' },
+]
+
+// Updated odds mapping: horse index -> new odds string
+export type OddsUpdate = Record<number, string>
+
+export interface RaceState {
+  trackCondition: TrackCondition
+  scratchedHorses: Set<number>
+  updatedOdds: OddsUpdate
+}
+
+export interface RaceStateActions {
+  setTrackCondition: (condition: TrackCondition) => void
+  toggleScratch: (horseIndex: number) => void
+  setScratch: (horseIndex: number, scratched: boolean) => void
+  updateOdds: (horseIndex: number, newOdds: string) => void
+  resetOdds: (horseIndex: number) => void
+  resetAll: () => void
+}
+
+export interface UseRaceStateReturn extends RaceState, RaceStateActions {
+  isScratched: (horseIndex: number) => boolean
+  getOdds: (horseIndex: number, originalOdds: string) => string
+  hasOddsChanged: (horseIndex: number) => boolean
+}
+
+const initialState: RaceState = {
+  trackCondition: 'fast',
+  scratchedHorses: new Set(),
+  updatedOdds: {},
+}
+
+export function useRaceState(): UseRaceStateReturn {
+  const [trackCondition, setTrackCondition] = useState<TrackCondition>(initialState.trackCondition)
+  const [scratchedHorses, setScratchedHorses] = useState<Set<number>>(initialState.scratchedHorses)
+  const [updatedOdds, setUpdatedOdds] = useState<OddsUpdate>(initialState.updatedOdds)
+
+  // Toggle scratch status for a horse
+  const toggleScratch = useCallback((horseIndex: number) => {
+    setScratchedHorses(prev => {
+      const next = new Set(prev)
+      if (next.has(horseIndex)) {
+        next.delete(horseIndex)
+      } else {
+        next.add(horseIndex)
+      }
+      return next
+    })
+  }, [])
+
+  // Set scratch status explicitly
+  const setScratch = useCallback((horseIndex: number, scratched: boolean) => {
+    setScratchedHorses(prev => {
+      const next = new Set(prev)
+      if (scratched) {
+        next.add(horseIndex)
+      } else {
+        next.delete(horseIndex)
+      }
+      return next
+    })
+  }, [])
+
+  // Update odds for a horse
+  const updateOdds = useCallback((horseIndex: number, newOdds: string) => {
+    setUpdatedOdds(prev => ({
+      ...prev,
+      [horseIndex]: newOdds,
+    }))
+  }, [])
+
+  // Reset odds for a horse to original
+  const resetOdds = useCallback((horseIndex: number) => {
+    setUpdatedOdds(prev => {
+      const next = { ...prev }
+      delete next[horseIndex]
+      return next
+    })
+  }, [])
+
+  // Reset all state to initial
+  const resetAll = useCallback(() => {
+    setTrackCondition(initialState.trackCondition)
+    setScratchedHorses(new Set())
+    setUpdatedOdds({})
+  }, [])
+
+  // Check if a horse is scratched
+  const isScratched = useCallback((horseIndex: number): boolean => {
+    return scratchedHorses.has(horseIndex)
+  }, [scratchedHorses])
+
+  // Get current odds for a horse (updated or original)
+  const getOdds = useCallback((horseIndex: number, originalOdds: string): string => {
+    return updatedOdds[horseIndex] ?? originalOdds
+  }, [updatedOdds])
+
+  // Check if odds have been changed from original
+  const hasOddsChanged = useCallback((horseIndex: number): boolean => {
+    return horseIndex in updatedOdds
+  }, [updatedOdds])
+
+  return useMemo(() => ({
+    // State
+    trackCondition,
+    scratchedHorses,
+    updatedOdds,
+    // Actions
+    setTrackCondition,
+    toggleScratch,
+    setScratch,
+    updateOdds,
+    resetOdds,
+    resetAll,
+    // Helpers
+    isScratched,
+    getOdds,
+    hasOddsChanged,
+  }), [
+    trackCondition,
+    scratchedHorses,
+    updatedOdds,
+    toggleScratch,
+    setScratch,
+    updateOdds,
+    resetOdds,
+    resetAll,
+    isScratched,
+    getOdds,
+    hasOddsChanged,
+  ])
+}

--- a/src/index.css
+++ b/src/index.css
@@ -150,3 +150,239 @@ body {
   color: var(--color-on-surface);
   flex-shrink: 0;
 }
+
+/* ============================================
+   Race Controls Styles
+   ============================================ */
+
+.race-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-outline);
+}
+
+.race-controls-section {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.race-controls-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(238, 239, 241, 0.5);
+}
+
+.race-controls-icon {
+  font-size: 1rem;
+  color: var(--color-primary);
+}
+
+/* Select Dropdown */
+.select-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.race-select {
+  appearance: none;
+  background-color: var(--color-surface-variant);
+  border: 1px solid var(--color-outline);
+  border-radius: 8px;
+  padding: 0.625rem 2.5rem 0.625rem 1rem;
+  font-size: 0.875rem;
+  color: var(--color-on-surface);
+  cursor: pointer;
+  min-height: 44px;
+  min-width: 150px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.race-select:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.race-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(25, 171, 181, 0.2);
+}
+
+.race-select option {
+  background-color: var(--color-surface);
+  color: var(--color-on-surface);
+  padding: 0.5rem;
+}
+
+.select-chevron {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.25rem;
+  color: rgba(238, 239, 241, 0.5);
+  pointer-events: none;
+}
+
+/* ============================================
+   Scratch Horse Styles
+   ============================================ */
+
+.scratch-checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.scratch-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.scratch-box {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--color-outline);
+  border-radius: 6px;
+  background-color: transparent;
+  transition: all 0.15s ease;
+}
+
+.scratch-icon {
+  font-size: 1.125rem;
+  color: rgba(238, 239, 241, 0.3);
+  transition: color 0.15s ease;
+}
+
+.scratch-input:checked + .scratch-box {
+  background-color: rgba(239, 68, 68, 0.15);
+  border-color: rgba(239, 68, 68, 0.5);
+}
+
+.scratch-input:checked + .scratch-box .scratch-icon {
+  color: #ef4444;
+}
+
+.scratch-checkbox:hover .scratch-box {
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+.scratch-input:focus + .scratch-box {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(25, 171, 181, 0.2);
+}
+
+/* Scratched row styles */
+.race-row-scratched {
+  background-color: #2A2A2C !important;
+}
+
+.race-row-scratched td {
+  color: rgba(238, 239, 241, 0.4);
+}
+
+.horse-name-scratched {
+  text-decoration: line-through;
+  color: rgba(238, 239, 241, 0.4) !important;
+}
+
+.mobile-card-scratched {
+  background-color: #2A2A2C;
+}
+
+.mobile-card-scratched .text-foreground,
+.mobile-card-scratched .text-white\/70 {
+  color: rgba(238, 239, 241, 0.4);
+}
+
+/* ============================================
+   Editable Odds Styles
+   ============================================ */
+
+.odds-display {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  background: transparent;
+  border: none;
+  padding: 0.375rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-primary);
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  min-height: 44px;
+  min-width: 60px;
+}
+
+.odds-display:hover:not(:disabled) {
+  background-color: rgba(25, 171, 181, 0.1);
+}
+
+.odds-display:focus {
+  outline: none;
+  background-color: rgba(25, 171, 181, 0.15);
+}
+
+.odds-edit-icon {
+  font-size: 0.875rem;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  color: rgba(238, 239, 241, 0.5);
+}
+
+.odds-display:hover .odds-edit-icon,
+.odds-display:focus .odds-edit-icon {
+  opacity: 1;
+}
+
+.odds-changed {
+  color: var(--color-primary);
+  background-color: rgba(25, 171, 181, 0.1);
+  border: 1px solid rgba(25, 171, 181, 0.3);
+}
+
+.odds-changed .odds-edit-icon {
+  opacity: 0.7;
+}
+
+.odds-disabled {
+  color: rgba(238, 239, 241, 0.3);
+  cursor: not-allowed;
+}
+
+.odds-input {
+  background-color: var(--color-surface-variant);
+  border: 1px solid var(--color-primary);
+  border-radius: 6px;
+  padding: 0.375rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-on-surface);
+  text-align: right;
+  width: 70px;
+  min-height: 36px;
+  font-variant-numeric: tabular-nums;
+  box-shadow: 0 0 0 2px rgba(25, 171, 181, 0.2);
+}
+
+.odds-input:focus {
+  outline: none;
+}


### PR DESCRIPTION
- Create useRaceState hook for managing track condition, scratched horses, and live odds
- Add RaceControls component with Material 3 styled track condition dropdown
- Update RaceTable with scratch checkboxes (grays out row, strikes through name)
- Add editable odds fields with click-to-edit, auto-save on blur
- Style all controls with dark theme, teal accent (#19abb5), 44px touch targets