### PR TITLE
Build basic scoring calculation engine

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -386,3 +386,31 @@ body {
 .odds-input:focus {
   outline: none;
 }
+
+/* ============================================
+   Score Badge Styles
+   ============================================ */
+
+.score-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 8px;
+  border: 1px solid;
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: transform 0.15s ease;
+}
+
+.score-badge:hover {
+  transform: scale(1.05);
+}
+
+/* Score badge in mobile view */
+.mobile-horse-card .score-badge {
+  min-width: 2.5rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8125rem;
+}

--- a/src/lib/scoring/baseScoring.ts
+++ b/src/lib/scoring/baseScoring.ts
@@ -1,0 +1,303 @@
+import type { HorseEntry, RaceHeader } from '../../types/drf'
+import type { TrackCondition } from '../../hooks/useRaceState'
+
+// Score breakdown for transparency
+export interface ScoreBreakdown {
+  connections: { total: number; trainer: number; jockey: number }
+  postPosition: { total: number; reasoning: string }
+  speedFigure: { total: number; reasoning: string }
+  form: { total: number; reasoning: string }
+  equipment: { total: number; reasoning: string }
+  pace: { total: number; reasoning: string }
+}
+
+// Placeholder trainer scores - will be replaced with real data
+const TRAINER_SCORES: Record<string, number> = {
+  // Top trainers get higher scores
+  'BAFFERT': 25,
+  'PLETCHER': 24,
+  'ASMUSSEN': 23,
+  'COX': 22,
+  'MOTT': 21,
+}
+
+// Placeholder jockey scores - will be replaced with real data
+const JOCKEY_SCORES: Record<string, number> = {
+  'VELAZQUEZ': 25,
+  'PRAT': 24,
+  'ROSARIO': 23,
+  'SAEZ': 22,
+  'ORTIZ': 21,
+  'CASTELLANO': 20,
+}
+
+/**
+ * A. Calculate Connections Score (max 50 points)
+ * Trainer base score + Jockey base score
+ */
+export function calculateConnectionsScore(horse: HorseEntry): ScoreBreakdown['connections'] {
+  const trainerUpper = horse.trainerName.toUpperCase()
+  const jockeyUpper = horse.jockeyName.toUpperCase()
+
+  // Look up trainer score (check if name contains known trainer)
+  let trainerScore = 12 // Default base score
+  for (const [name, score] of Object.entries(TRAINER_SCORES)) {
+    if (trainerUpper.includes(name)) {
+      trainerScore = score
+      break
+    }
+  }
+
+  // Look up jockey score (check if name contains known jockey)
+  let jockeyScore = 12 // Default base score
+  for (const [name, score] of Object.entries(JOCKEY_SCORES)) {
+    if (jockeyUpper.includes(name)) {
+      jockeyScore = score
+      break
+    }
+  }
+
+  return {
+    total: trainerScore + jockeyScore,
+    trainer: trainerScore,
+    jockey: jockeyScore,
+  }
+}
+
+/**
+ * Parse distance string to determine if sprint or route
+ * Sprint: 6F-7F
+ * Route: 1M+
+ */
+function parseDistance(distance: string): { isSprint: boolean; isRoute: boolean; furlongs: number } {
+  const distLower = distance.toLowerCase()
+
+  // Handle mile distances
+  if (distLower.includes('m')) {
+    const mileMatch = distLower.match(/(\d+\.?\d*)\s*m/)
+    if (mileMatch) {
+      const miles = parseFloat(mileMatch[1])
+      const furlongs = miles * 8
+      return { isSprint: false, isRoute: true, furlongs }
+    }
+  }
+
+  // Handle furlong distances
+  const furlongMatch = distLower.match(/(\d+\.?\d*)\s*f/)
+  if (furlongMatch) {
+    const furlongs = parseFloat(furlongMatch[1])
+    return {
+      isSprint: furlongs >= 6 && furlongs <= 7,
+      isRoute: furlongs >= 8,
+      furlongs,
+    }
+  }
+
+  // Default to sprint if can't parse
+  return { isSprint: true, isRoute: false, furlongs: 6 }
+}
+
+/**
+ * B. Calculate Post Position Score (max 45 points)
+ * Sprint: Posts 4-5 best, 2-3 good
+ * Route: Post 5 best, 2-4 good
+ */
+export function calculatePostPositionScore(
+  horse: HorseEntry,
+  raceHeader: RaceHeader
+): ScoreBreakdown['postPosition'] {
+  const pp = horse.postPosition
+  const { isSprint, isRoute } = parseDistance(raceHeader.distance)
+
+  let score = 10 // Base score
+  let reasoning = ''
+
+  if (isSprint) {
+    // Sprint distances (6F-7F)
+    if (pp === 4) {
+      score = 20
+      reasoning = 'Ideal sprint post (4)'
+    } else if (pp === 5) {
+      score = 18
+      reasoning = 'Good sprint post (5)'
+    } else if (pp === 3) {
+      score = 14
+      reasoning = 'Decent sprint post (3)'
+    } else if (pp === 2) {
+      score = 12
+      reasoning = 'Inside sprint post (2)'
+    } else if (pp === 1) {
+      score = 8
+      reasoning = 'Rail can be tricky in sprints'
+    } else if (pp >= 6 && pp <= 8) {
+      score = 10
+      reasoning = 'Outside post in sprint'
+    } else {
+      score = 5
+      reasoning = 'Far outside post in sprint'
+    }
+  } else if (isRoute) {
+    // Route distances (1M+)
+    if (pp === 5) {
+      score = 20
+      reasoning = 'Ideal route post (5)'
+    } else if (pp >= 2 && pp <= 4) {
+      score = 15
+      reasoning = 'Good inside route post'
+    } else if (pp === 6 || pp === 7) {
+      score = 12
+      reasoning = 'Mid-outside route post'
+    } else if (pp === 1) {
+      score = 10
+      reasoning = 'Rail - can save ground'
+    } else {
+      score = 8
+      reasoning = 'Wide post in route'
+    }
+  } else {
+    // Mid-distance
+    if (pp >= 3 && pp <= 5) {
+      score = 15
+      reasoning = 'Good mid-distance post'
+    } else {
+      score = 10
+      reasoning = 'Average post position'
+    }
+  }
+
+  // Adjust for turf (inside posts slightly better)
+  if (raceHeader.surface === 'turf' && pp <= 3) {
+    score = Math.min(score + 3, 20)
+    reasoning += ' (turf rail bonus)'
+  }
+
+  return {
+    total: score,
+    reasoning: `${reasoning} - ${raceHeader.distance}`,
+  }
+}
+
+/**
+ * Parse odds string to decimal number
+ * Handles formats like "3-1", "5/2", "3.5", "3.5-1"
+ */
+export function parseOdds(oddsStr: string): number {
+  const cleaned = oddsStr.trim().toUpperCase()
+
+  // Handle "EVEN" odds
+  if (cleaned === 'EVEN' || cleaned === 'EVN') {
+    return 1.0
+  }
+
+  // Handle "X-1" format (e.g., "5-1")
+  if (cleaned.includes('-')) {
+    const [num] = cleaned.split('-')
+    return parseFloat(num) || 10
+  }
+
+  // Handle "X/Y" format (e.g., "5/2")
+  if (cleaned.includes('/')) {
+    const [num, denom] = cleaned.split('/')
+    return parseFloat(num) / (parseFloat(denom) || 1)
+  }
+
+  // Handle plain number
+  return parseFloat(cleaned) || 10
+}
+
+/**
+ * C. Calculate Speed Figure Score (max 50 points)
+ * Uses morning line odds as proxy for now
+ * Favorites get 40-50 points, longshots get 0-20 points
+ */
+export function calculateSpeedFigureScore(
+  _horse: HorseEntry,
+  currentOdds: string
+): ScoreBreakdown['speedFigure'] {
+  const odds = parseOdds(currentOdds)
+
+  let score: number
+  let reasoning: string
+
+  if (odds <= 1) {
+    score = 50
+    reasoning = 'Heavy favorite (even money or less)'
+  } else if (odds <= 2) {
+    score = 45
+    reasoning = 'Strong favorite (2-1 or less)'
+  } else if (odds <= 3) {
+    score = 40
+    reasoning = 'Favorite (3-1 or less)'
+  } else if (odds <= 5) {
+    score = 35
+    reasoning = 'Low odds contender (5-1 or less)'
+  } else if (odds <= 8) {
+    score = 28
+    reasoning = 'Mid-odds contender'
+  } else if (odds <= 12) {
+    score = 20
+    reasoning = 'Higher odds runner'
+  } else if (odds <= 20) {
+    score = 12
+    reasoning = 'Longshot'
+  } else {
+    score = 5
+    reasoning = 'Extreme longshot'
+  }
+
+  return {
+    total: score,
+    reasoning: `${reasoning} (${currentOdds})`,
+  }
+}
+
+/**
+ * D. Calculate Form Score (max 30 points)
+ * Placeholder: 15-25 points based on program number for now
+ * Will be replaced with real form analysis later
+ */
+export function calculateFormScore(horse: HorseEntry): ScoreBreakdown['form'] {
+  // Use program number to create pseudo-random but consistent scores
+  const seed = horse.programNumber * 7 + horse.horseName.length
+  const score = 15 + (seed % 11) // 15-25 range
+
+  return {
+    total: score,
+    reasoning: 'Placeholder form score (to be replaced with real analysis)',
+  }
+}
+
+/**
+ * E. Calculate Equipment Score (max 25 points)
+ * Placeholder: 10-15 points for now
+ * Will be enhanced with real equipment change analysis
+ */
+export function calculateEquipmentScore(horse: HorseEntry): ScoreBreakdown['equipment'] {
+  // Base equipment score
+  const seed = horse.postPosition * 3 + horse.programNumber
+  const score = 10 + (seed % 6) // 10-15 range
+
+  return {
+    total: score,
+    reasoning: 'Placeholder equipment score (to be enhanced)',
+  }
+}
+
+/**
+ * F. Calculate Pace Score (max 40 points)
+ * Placeholder: 20-30 points for now
+ * Will be enhanced with real pace analysis
+ */
+export function calculatePaceScore(
+  horse: HorseEntry,
+  _trackCondition: TrackCondition
+): ScoreBreakdown['pace'] {
+  // Base pace score - will use track condition in future
+  const seed = horse.programNumber * 5 + horse.postPosition * 2
+  const score = 20 + (seed % 11) // 20-30 range
+
+  return {
+    total: score,
+    reasoning: 'Placeholder pace score (to be enhanced with running style analysis)',
+  }
+}

--- a/src/lib/scoring/index.ts
+++ b/src/lib/scoring/index.ts
@@ -1,0 +1,146 @@
+import type { HorseEntry, RaceHeader } from '../../types/drf'
+import type { TrackCondition } from '../../hooks/useRaceState'
+import {
+  calculateConnectionsScore,
+  calculatePostPositionScore,
+  calculateSpeedFigureScore,
+  calculateFormScore,
+  calculateEquipmentScore,
+  calculatePaceScore,
+  type ScoreBreakdown,
+} from './baseScoring'
+
+// Score limits by category
+export const SCORE_LIMITS = {
+  connections: 50,
+  postPosition: 45,
+  speedFigure: 50,
+  form: 30,
+  equipment: 25,
+  pace: 40,
+  total: 240,
+} as const
+
+// Score thresholds for color coding
+export const SCORE_THRESHOLDS = {
+  high: 180,    // 180+ = high score (teal)
+  medium: 140,  // 140-179 = medium score (darker teal)
+  low: 0,       // <140 = low score (gray)
+} as const
+
+// Score colors
+export const SCORE_COLORS = {
+  high: '#36d1da',
+  medium: '#19abb5',
+  low: '#888888',
+} as const
+
+export interface HorseScore {
+  total: number
+  breakdown: ScoreBreakdown
+  isScratched: boolean
+}
+
+/**
+ * Calculate the total score for a horse
+ * Returns a score from 0-240 with a full breakdown
+ */
+export function calculateHorseScore(
+  horse: HorseEntry,
+  raceHeader: RaceHeader,
+  currentOdds: string,
+  trackCondition: TrackCondition,
+  isScratched: boolean
+): HorseScore {
+  // Scratched horses get 0 score
+  if (isScratched) {
+    return {
+      total: 0,
+      breakdown: {
+        connections: { total: 0, trainer: 0, jockey: 0 },
+        postPosition: { total: 0, reasoning: 'Scratched' },
+        speedFigure: { total: 0, reasoning: 'Scratched' },
+        form: { total: 0, reasoning: 'Scratched' },
+        equipment: { total: 0, reasoning: 'Scratched' },
+        pace: { total: 0, reasoning: 'Scratched' },
+      },
+      isScratched: true,
+    }
+  }
+
+  // Calculate each category
+  const connections = calculateConnectionsScore(horse)
+  const postPosition = calculatePostPositionScore(horse, raceHeader)
+  const speedFigure = calculateSpeedFigureScore(horse, currentOdds)
+  const form = calculateFormScore(horse)
+  const equipment = calculateEquipmentScore(horse)
+  const pace = calculatePaceScore(horse, trackCondition)
+
+  // Sum up total score
+  const total =
+    connections.total +
+    postPosition.total +
+    speedFigure.total +
+    form.total +
+    equipment.total +
+    pace.total
+
+  return {
+    total,
+    breakdown: {
+      connections,
+      postPosition,
+      speedFigure,
+      form,
+      equipment,
+      pace,
+    },
+    isScratched: false,
+  }
+}
+
+/**
+ * Get the color for a score based on thresholds
+ */
+export function getScoreColor(score: number, isScratched: boolean): string {
+  if (isScratched) return SCORE_COLORS.low
+  if (score >= SCORE_THRESHOLDS.high) return SCORE_COLORS.high
+  if (score >= SCORE_THRESHOLDS.medium) return SCORE_COLORS.medium
+  return SCORE_COLORS.low
+}
+
+/**
+ * Calculate scores for all horses in a race and return sorted by score descending
+ */
+export function calculateRaceScores(
+  horses: HorseEntry[],
+  raceHeader: RaceHeader,
+  getOdds: (index: number, originalOdds: string) => string,
+  isScratched: (index: number) => boolean,
+  trackCondition: TrackCondition
+): Array<{ horse: HorseEntry; index: number; score: HorseScore }> {
+  const scores = horses.map((horse, index) => ({
+    horse,
+    index,
+    score: calculateHorseScore(
+      horse,
+      raceHeader,
+      getOdds(index, horse.morningLineOdds),
+      trackCondition,
+      isScratched(index)
+    ),
+  }))
+
+  // Sort by score descending (scratched horses go to bottom)
+  return scores.sort((a, b) => {
+    // Scratched horses always at bottom
+    if (a.score.isScratched && !b.score.isScratched) return 1
+    if (!a.score.isScratched && b.score.isScratched) return -1
+    // Otherwise sort by score descending
+    return b.score.total - a.score.total
+  })
+}
+
+// Re-export types and utilities from baseScoring
+export type { ScoreBreakdown } from './baseScoring'
+export { parseOdds } from './baseScoring'


### PR DESCRIPTION
- Create baseScoring.ts with 6 scoring categories:
  - Connections (trainer/jockey): max 50 points
  - Post Position (sprint/route adjusted): max 45 points
  - Speed Figure (odds-based proxy): max 50 points
  - Form (placeholder): max 30 points
  - Equipment (placeholder): max 25 points
  - Pace (placeholder): max 40 points

- Create scoring/index.ts to combine scores (0-240 range)
- Add Score column to RaceTable with color-coded badges
- Sort horses by score descending (scratched at bottom)
- Scores recalculate reactively on scratch/odds/track changes