### PR TITLE
Create track intelligence database schema

### DIFF
--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -1,0 +1,407 @@
+/**
+ * Track Intelligence Database
+ * Contains track-specific data for handicapping calculations
+ */
+
+import type { TrackData } from './trackSchema'
+
+/**
+ * Santa Anita Park - Arcadia, California
+ * One of the premier tracks in North America
+ */
+const santaAnita: TrackData = {
+  code: 'SA',
+  name: 'Santa Anita Park',
+  location: 'Arcadia, California',
+  state: 'CA',
+  measurements: {
+    dirt: {
+      circumference: 1.0,
+      stretchLength: 990,
+      turnRadius: 280,
+      trackWidth: 80,
+      chutes: [6, 6.5]
+    },
+    turf: {
+      circumference: 0.875,
+      stretchLength: 990,
+      turnRadius: 240,
+      trackWidth: 75,
+      chutes: [6.5]
+    }
+  },
+  postPositionBias: {
+    dirt: [
+      {
+        distance: 'sprint',
+        minFurlongs: 5,
+        maxFurlongs: 7,
+        winPercentByPost: [8, 12, 14, 16, 15, 12, 10, 7, 4, 2],
+        favoredPosts: [3, 4, 5],
+        biasDescription: 'Middle posts (3-5) favored in sprints'
+      },
+      {
+        distance: 'route',
+        minFurlongs: 8,
+        maxFurlongs: 12,
+        winPercentByPost: [10, 13, 14, 15, 14, 12, 10, 7, 4, 1],
+        favoredPosts: [3, 4, 5],
+        biasDescription: 'Posts 3-5 slight advantage in routes'
+      }
+    ],
+    turf: [
+      {
+        distance: 'sprint',
+        minFurlongs: 5,
+        maxFurlongs: 7,
+        winPercentByPost: [14, 15, 14, 13, 12, 11, 10, 6, 3, 2],
+        favoredPosts: [1, 2, 3],
+        biasDescription: 'Inside posts favored on turf sprints'
+      },
+      {
+        distance: 'route',
+        minFurlongs: 8,
+        maxFurlongs: 12,
+        winPercentByPost: [12, 14, 14, 13, 12, 11, 10, 8, 4, 2],
+        favoredPosts: [2, 3, 4],
+        biasDescription: 'Posts 2-4 have edge in turf routes'
+      }
+    ]
+  },
+  speedBias: [
+    {
+      surface: 'dirt',
+      earlySpeedWinRate: 58,
+      paceAdvantageRating: 6,
+      description: 'Moderate speed bias; stalkers can compete'
+    },
+    {
+      surface: 'turf',
+      earlySpeedWinRate: 42,
+      paceAdvantageRating: 4,
+      description: 'Fair turf course; closers have chances'
+    }
+  ],
+  surfaces: [
+    {
+      baseType: 'dirt',
+      composition: 'Sandy loam',
+      playingStyle: 'fair',
+      drainage: 'excellent'
+    },
+    {
+      baseType: 'turf',
+      composition: 'Bermuda/Rye blend',
+      playingStyle: 'fair',
+      drainage: 'good'
+    }
+  ],
+  seasonalPatterns: [
+    {
+      season: 'winter',
+      months: [12, 1, 2],
+      typicalCondition: 'Fast to Good',
+      speedAdjustment: -1,
+      notes: 'Premium winter meet; slightly slower due to rain potential'
+    },
+    {
+      season: 'spring',
+      months: [3, 4, 5],
+      typicalCondition: 'Fast',
+      speedAdjustment: 0,
+      notes: 'Ideal racing conditions'
+    },
+    {
+      season: 'fall',
+      months: [9, 10, 11],
+      typicalCondition: 'Fast',
+      speedAdjustment: 1,
+      notes: 'Oak Tree meet; fast and dry conditions'
+    }
+  ],
+  winningTimes: [
+    { distance: '6f', furlongs: 6, surface: 'dirt', claimingAvg: 70.5, allowanceAvg: 69.2, stakesAvg: 68.0 },
+    { distance: '1m', furlongs: 8, surface: 'dirt', claimingAvg: 96.8, allowanceAvg: 95.0, stakesAvg: 93.5 },
+    { distance: '1m1/8', furlongs: 9, surface: 'dirt', claimingAvg: 110.5, allowanceAvg: 108.8, stakesAvg: 107.0 },
+    { distance: '6f', furlongs: 6, surface: 'turf', claimingAvg: 69.0, allowanceAvg: 67.8, stakesAvg: 66.5 },
+    { distance: '1m', furlongs: 8, surface: 'turf', claimingAvg: 95.5, allowanceAvg: 94.0, stakesAvg: 92.5 }
+  ],
+  lastUpdated: '2024-12-01',
+  dataQuality: 'estimated'
+}
+
+/**
+ * Gulfstream Park - Hallandale Beach, Florida
+ * Premier winter racing destination
+ */
+const gulfstream: TrackData = {
+  code: 'GP',
+  name: 'Gulfstream Park',
+  location: 'Hallandale Beach, Florida',
+  state: 'FL',
+  measurements: {
+    dirt: {
+      circumference: 1.0,
+      stretchLength: 988,
+      turnRadius: 275,
+      trackWidth: 80,
+      chutes: [7]
+    },
+    turf: {
+      circumference: 0.875,
+      stretchLength: 988,
+      turnRadius: 230,
+      trackWidth: 70,
+      chutes: []
+    }
+  },
+  postPositionBias: {
+    dirt: [
+      {
+        distance: 'sprint',
+        minFurlongs: 5,
+        maxFurlongs: 7,
+        winPercentByPost: [6, 10, 13, 17, 18, 14, 10, 7, 3, 2],
+        favoredPosts: [4, 5, 6],
+        biasDescription: 'Posts 4-5 strongly favored in sprints'
+      },
+      {
+        distance: 'route',
+        minFurlongs: 8,
+        maxFurlongs: 12,
+        winPercentByPost: [9, 12, 14, 15, 14, 13, 10, 8, 3, 2],
+        favoredPosts: [3, 4, 5],
+        biasDescription: 'Middle posts have slight edge in routes'
+      }
+    ],
+    turf: [
+      {
+        distance: 'sprint',
+        minFurlongs: 5,
+        maxFurlongs: 7,
+        winPercentByPost: [15, 16, 14, 13, 12, 11, 9, 6, 3, 1],
+        favoredPosts: [1, 2],
+        biasDescription: 'Strong inside bias on turf sprints'
+      },
+      {
+        distance: 'route',
+        minFurlongs: 8,
+        maxFurlongs: 12,
+        winPercentByPost: [13, 14, 14, 13, 12, 11, 10, 8, 4, 1],
+        favoredPosts: [1, 2, 3],
+        biasDescription: 'Inside posts favored in turf routes'
+      }
+    ]
+  },
+  speedBias: [
+    {
+      surface: 'dirt',
+      earlySpeedWinRate: 62,
+      paceAdvantageRating: 7,
+      description: 'Strong speed bias; leaders have clear advantage'
+    },
+    {
+      surface: 'turf',
+      earlySpeedWinRate: 48,
+      paceAdvantageRating: 5,
+      description: 'Moderate turf; pace scenarios matter'
+    }
+  ],
+  surfaces: [
+    {
+      baseType: 'dirt',
+      composition: 'Sandy base',
+      playingStyle: 'speed-favoring',
+      drainage: 'excellent'
+    },
+    {
+      baseType: 'turf',
+      composition: 'Bermuda',
+      playingStyle: 'fair',
+      drainage: 'good'
+    }
+  ],
+  seasonalPatterns: [
+    {
+      season: 'winter',
+      months: [12, 1, 2, 3],
+      typicalCondition: 'Fast',
+      speedAdjustment: 1,
+      notes: 'Championship meet; premium conditions and competition'
+    },
+    {
+      season: 'spring',
+      months: [4, 5],
+      typicalCondition: 'Fast to Good',
+      speedAdjustment: 0,
+      notes: 'End of main meet; quality remains high'
+    },
+    {
+      season: 'summer',
+      months: [6, 7, 8],
+      typicalCondition: 'Fast/Sloppy',
+      speedAdjustment: -1,
+      notes: 'Afternoon thunderstorms affect cards frequently'
+    }
+  ],
+  winningTimes: [
+    { distance: '6f', furlongs: 6, surface: 'dirt', claimingAvg: 70.0, allowanceAvg: 68.8, stakesAvg: 67.5 },
+    { distance: '1m', furlongs: 8, surface: 'dirt', claimingAvg: 96.2, allowanceAvg: 94.5, stakesAvg: 93.0 },
+    { distance: '1m1/8', furlongs: 9, surface: 'dirt', claimingAvg: 110.0, allowanceAvg: 108.2, stakesAvg: 106.5 },
+    { distance: '5f', furlongs: 5, surface: 'turf', claimingAvg: 57.0, allowanceAvg: 55.8, stakesAvg: 54.5 },
+    { distance: '1m', furlongs: 8, surface: 'turf', claimingAvg: 95.0, allowanceAvg: 93.5, stakesAvg: 92.0 }
+  ],
+  lastUpdated: '2024-12-01',
+  dataQuality: 'estimated'
+}
+
+/**
+ * Churchill Downs - Louisville, Kentucky
+ * Home of the Kentucky Derby
+ */
+const churchillDowns: TrackData = {
+  code: 'CD',
+  name: 'Churchill Downs',
+  location: 'Louisville, Kentucky',
+  state: 'KY',
+  measurements: {
+    dirt: {
+      circumference: 1.0,
+      stretchLength: 1234,
+      turnRadius: 295,
+      trackWidth: 80,
+      chutes: [6, 7]
+    },
+    turf: {
+      circumference: 0.875,
+      stretchLength: 1234,
+      turnRadius: 250,
+      trackWidth: 70,
+      chutes: []
+    }
+  },
+  postPositionBias: {
+    dirt: [
+      {
+        distance: 'sprint',
+        minFurlongs: 5,
+        maxFurlongs: 7,
+        winPercentByPost: [7, 11, 14, 16, 16, 13, 10, 7, 4, 2],
+        favoredPosts: [4, 5],
+        biasDescription: 'Posts 4-5 ideal in dirt sprints'
+      },
+      {
+        distance: 'route',
+        minFurlongs: 8,
+        maxFurlongs: 12,
+        winPercentByPost: [10, 12, 13, 14, 14, 12, 11, 8, 4, 2],
+        favoredPosts: [4, 5],
+        biasDescription: 'Long stretch helps all; middle still best'
+      }
+    ],
+    turf: [
+      {
+        distance: 'sprint',
+        minFurlongs: 5,
+        maxFurlongs: 7,
+        winPercentByPost: [13, 15, 14, 13, 12, 11, 10, 7, 3, 2],
+        favoredPosts: [1, 2, 3],
+        biasDescription: 'Inside posts have advantage on turf sprints'
+      },
+      {
+        distance: 'route',
+        minFurlongs: 8,
+        maxFurlongs: 12,
+        winPercentByPost: [11, 13, 14, 13, 13, 12, 10, 8, 4, 2],
+        favoredPosts: [2, 3, 4],
+        biasDescription: 'Slight inside edge in turf routes'
+      }
+    ]
+  },
+  speedBias: [
+    {
+      surface: 'dirt',
+      earlySpeedWinRate: 52,
+      paceAdvantageRating: 5,
+      description: 'Long stretch allows closers; fair track'
+    },
+    {
+      surface: 'turf',
+      earlySpeedWinRate: 45,
+      paceAdvantageRating: 4,
+      description: 'Turf course plays fair; tactical races'
+    }
+  ],
+  surfaces: [
+    {
+      baseType: 'dirt',
+      composition: 'Sandy loam',
+      playingStyle: 'fair',
+      drainage: 'good'
+    },
+    {
+      baseType: 'turf',
+      composition: 'Kentucky Bluegrass',
+      playingStyle: 'fair',
+      drainage: 'good'
+    }
+  ],
+  seasonalPatterns: [
+    {
+      season: 'spring',
+      months: [4, 5, 6],
+      typicalCondition: 'Fast to Good',
+      speedAdjustment: 0,
+      notes: 'Derby/Oaks meet; premium conditions but variable weather'
+    },
+    {
+      season: 'summer',
+      months: [7, 8],
+      typicalCondition: 'Fast',
+      speedAdjustment: 1,
+      notes: 'Hot and dry; fast track'
+    },
+    {
+      season: 'fall',
+      months: [9, 10, 11],
+      typicalCondition: 'Fast',
+      speedAdjustment: 1,
+      notes: 'Fall meet includes Stakes bonanza; excellent conditions'
+    }
+  ],
+  winningTimes: [
+    { distance: '6f', furlongs: 6, surface: 'dirt', claimingAvg: 70.2, allowanceAvg: 69.0, stakesAvg: 67.8 },
+    { distance: '1m', furlongs: 8, surface: 'dirt', claimingAvg: 96.5, allowanceAvg: 94.8, stakesAvg: 93.2 },
+    { distance: '1m1/4', furlongs: 10, surface: 'dirt', claimingAvg: 123.0, allowanceAvg: 121.0, stakesAvg: 119.0 },
+    { distance: '5f', furlongs: 5, surface: 'turf', claimingAvg: 57.5, allowanceAvg: 56.2, stakesAvg: 55.0 },
+    { distance: '1m', furlongs: 8, surface: 'turf', claimingAvg: 95.8, allowanceAvg: 94.2, stakesAvg: 92.8 }
+  ],
+  lastUpdated: '2024-12-01',
+  dataQuality: 'estimated'
+}
+
+/**
+ * Track database indexed by track code
+ */
+export const trackDatabase: Map<string, TrackData> = new Map([
+  ['SA', santaAnita],
+  ['GP', gulfstream],
+  ['CD', churchillDowns]
+])
+
+/**
+ * Get list of all available track codes
+ */
+export function getAvailableTrackCodes(): string[] {
+  return Array.from(trackDatabase.keys())
+}
+
+/**
+ * Check if a track exists in the database
+ */
+export function hasTrackData(trackCode: string): boolean {
+  return trackDatabase.has(trackCode.toUpperCase())
+}
+
+// Re-export types
+export type { TrackData, PostPositionBias, SpeedBias, TrackBiasSummary } from './trackSchema'

--- a/src/data/tracks/trackSchema.ts
+++ b/src/data/tracks/trackSchema.ts
@@ -1,0 +1,148 @@
+/**
+ * Track Intelligence Schema
+ * Defines the structure for track-specific data used in handicapping
+ */
+
+/**
+ * Post position bias data for a specific distance range
+ */
+export interface PostPositionBias {
+  /** Distance range identifier (e.g., "6f", "1m", "1m1/4") */
+  distance: string
+  /** Minimum distance in furlongs for this range */
+  minFurlongs: number
+  /** Maximum distance in furlongs for this range */
+  maxFurlongs: number
+  /** Win percentage by post position (index 0 = post 1, etc.) */
+  winPercentByPost: number[]
+  /** Posts that are statistically favored (1-indexed) */
+  favoredPosts: number[]
+  /** Brief description of the bias pattern */
+  biasDescription: string
+}
+
+/**
+ * Speed bias data indicating early speed advantage
+ */
+export interface SpeedBias {
+  /** Surface type this bias applies to */
+  surface: 'dirt' | 'turf' | 'synthetic'
+  /** Percentage of races won by early speed horses */
+  earlySpeedWinRate: number
+  /** Rating from 1-10 indicating pace advantage (10 = very strong speed bias) */
+  paceAdvantageRating: number
+  /** Description of track's pace tendencies */
+  description: string
+}
+
+/**
+ * Track measurement specifications
+ */
+export interface TrackMeasurements {
+  /** Main track circumference in miles */
+  circumference: number
+  /** Stretch length in feet */
+  stretchLength: number
+  /** Turn radius in feet (approximate) */
+  turnRadius: number
+  /** Width of track in feet */
+  trackWidth: number
+  /** Chute distances available (in furlongs) */
+  chutes: number[]
+}
+
+/**
+ * Surface characteristics for the track
+ */
+export interface SurfaceCharacteristics {
+  /** Base material type */
+  baseType: 'dirt' | 'turf' | 'synthetic'
+  /** Specific surface composition or turf type */
+  composition: string
+  /** How the surface typically plays (speed-favoring, fair, tiring) */
+  playingStyle: 'speed-favoring' | 'fair' | 'tiring' | 'deep'
+  /** Drainage quality affecting off-track conditions */
+  drainage: 'excellent' | 'good' | 'fair' | 'poor'
+}
+
+/**
+ * Seasonal patterns affecting track performance
+ */
+export interface SeasonalPattern {
+  /** Season identifier */
+  season: 'winter' | 'spring' | 'summer' | 'fall'
+  /** Months this pattern applies to */
+  months: number[]
+  /** Expected track condition variance */
+  typicalCondition: string
+  /** Speed figure adjustment (positive = faster times expected) */
+  speedAdjustment: number
+  /** Notes about seasonal impact */
+  notes: string
+}
+
+/**
+ * Average winning times by distance for par time calculations
+ */
+export interface WinningTimeByDistance {
+  /** Distance identifier */
+  distance: string
+  /** Distance in furlongs */
+  furlongs: number
+  /** Surface type */
+  surface: 'dirt' | 'turf' | 'synthetic'
+  /** Average winning time in seconds for claiming races ($25k-$50k) */
+  claimingAvg: number
+  /** Average winning time in seconds for allowance races */
+  allowanceAvg: number
+  /** Average winning time in seconds for stakes races */
+  stakesAvg: number
+}
+
+/**
+ * Main track data interface containing all track intelligence
+ */
+export interface TrackData {
+  /** Unique track code (e.g., "SA", "GP", "CD") */
+  code: string
+  /** Full track name */
+  name: string
+  /** City and state location */
+  location: string
+  /** State abbreviation */
+  state: string
+  /** Track measurements and dimensions */
+  measurements: {
+    dirt: TrackMeasurements
+    turf?: TrackMeasurements
+  }
+  /** Post position biases by distance and surface */
+  postPositionBias: {
+    dirt: PostPositionBias[]
+    turf?: PostPositionBias[]
+  }
+  /** Speed/pace bias data by surface */
+  speedBias: SpeedBias[]
+  /** Surface characteristics */
+  surfaces: SurfaceCharacteristics[]
+  /** Seasonal patterns */
+  seasonalPatterns: SeasonalPattern[]
+  /** Average winning times by distance */
+  winningTimes: WinningTimeByDistance[]
+  /** Last updated timestamp */
+  lastUpdated: string
+  /** Data quality indicator */
+  dataQuality: 'verified' | 'preliminary' | 'estimated'
+}
+
+/**
+ * Simplified track bias summary for UI display
+ */
+export interface TrackBiasSummary {
+  trackCode: string
+  trackName: string
+  speedBiasPercent: number
+  speedBiasDescription: string
+  favoredPostsDescription: string
+  isDataAvailable: boolean
+}

--- a/src/index.css
+++ b/src/index.css
@@ -414,3 +414,150 @@ body {
   padding: 0.25rem 0.5rem;
   font-size: 0.8125rem;
 }
+
+/* ============================================
+   Track Bias Styles
+   ============================================ */
+
+.track-bias-container {
+  position: relative;
+}
+
+.track-bias-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bias-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border-radius: 16px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.bias-chip.speed-bias {
+  background-color: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+  border: 1px solid rgba(245, 158, 11, 0.3);
+}
+
+.bias-chip.post-bias {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: #3b82f6;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
+.bias-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 50%;
+  background-color: var(--color-surface-variant);
+  color: rgba(238, 239, 241, 0.5);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.bias-info-btn:hover,
+.bias-info-btn:focus {
+  background-color: var(--color-primary);
+  color: #fff;
+  outline: none;
+}
+
+/* Track Bias Tooltip */
+.bias-tooltip {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  z-index: 50;
+  min-width: 280px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+  animation: tooltip-fade-in 0.15s ease;
+}
+
+@keyframes tooltip-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.tooltip-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background-color: var(--color-surface-variant);
+  border-bottom: 1px solid var(--color-outline);
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-primary);
+}
+
+.tooltip-content {
+  padding: 0.75rem 1rem;
+}
+
+.tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.375rem 0;
+}
+
+.tooltip-label {
+  font-size: 0.75rem;
+  color: rgba(238, 239, 241, 0.6);
+}
+
+.tooltip-value {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-on-surface);
+}
+
+.tooltip-desc {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--color-outline);
+  font-size: 0.75rem;
+  color: rgba(238, 239, 241, 0.5);
+  font-style: italic;
+}
+
+.tooltip-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  background-color: rgba(25, 171, 181, 0.1);
+  border-top: 1px solid var(--color-outline);
+  font-size: 0.6875rem;
+  color: var(--color-primary);
+}
+
+/* Mobile responsive tooltip */
+@media (max-width: 640px) {
+  .bias-tooltip {
+    left: 0;
+    right: 0;
+    min-width: auto;
+  }
+}

--- a/src/lib/scoring/index.ts
+++ b/src/lib/scoring/index.ts
@@ -58,7 +58,7 @@ export function calculateHorseScore(
       total: 0,
       breakdown: {
         connections: { total: 0, trainer: 0, jockey: 0 },
-        postPosition: { total: 0, reasoning: 'Scratched' },
+        postPosition: { total: 0, reasoning: 'Scratched', trackBiasApplied: false },
         speedFigure: { total: 0, reasoning: 'Scratched' },
         form: { total: 0, reasoning: 'Scratched' },
         equipment: { total: 0, reasoning: 'Scratched' },

--- a/src/lib/trackIntelligence.ts
+++ b/src/lib/trackIntelligence.ts
@@ -1,0 +1,209 @@
+/**
+ * Track Intelligence Service
+ * Provides functions to retrieve and analyze track-specific data
+ */
+
+import { trackDatabase, hasTrackData } from '../data/tracks'
+import type {
+  TrackData,
+  PostPositionBias,
+  SpeedBias,
+  TrackBiasSummary
+} from '../data/tracks/trackSchema'
+
+/**
+ * Parse distance string to furlongs
+ * Handles formats like "6F", "1M", "1M 1/16", "1 1/8M", etc.
+ */
+export function parseDistanceToFurlongs(distance: string): number {
+  const normalized = distance.toUpperCase().trim()
+
+  // Handle furlong formats: "6F", "5.5F", "6 1/2F"
+  if (normalized.includes('F') && !normalized.includes('M')) {
+    const match = normalized.match(/(\d+(?:\.\d+)?)\s*(?:(\d+)\/(\d+))?\s*F/)
+    if (match) {
+      const whole = parseFloat(match[1])
+      const numerator = match[2] ? parseInt(match[2]) : 0
+      const denominator = match[3] ? parseInt(match[3]) : 1
+      return whole + numerator / denominator
+    }
+  }
+
+  // Handle mile formats: "1M", "1 1/8M", "1M 1/16", "1 1/4 Miles"
+  if (normalized.includes('M')) {
+    // Pattern for miles with fractions
+    const match = normalized.match(/(\d+)\s*(?:(\d+)\/(\d+))?\s*M/)
+    if (match) {
+      const wholeMiles = parseInt(match[1])
+      const numerator = match[2] ? parseInt(match[2]) : 0
+      const denominator = match[3] ? parseInt(match[3]) : 1
+      const totalMiles = wholeMiles + numerator / denominator
+      return totalMiles * 8 // 8 furlongs per mile
+    }
+  }
+
+  // Default fallback - try to parse as number
+  const numMatch = normalized.match(/(\d+(?:\.\d+)?)/)
+  if (numMatch) {
+    return parseFloat(numMatch[1])
+  }
+
+  return 8 // Default to 1 mile if parsing fails
+}
+
+/**
+ * Determine if a distance is a sprint or route
+ */
+export function getDistanceCategory(furlongs: number): 'sprint' | 'route' {
+  return furlongs < 8 ? 'sprint' : 'route'
+}
+
+/**
+ * Get track data by track code
+ * Returns undefined if track is not in database
+ */
+export function getTrackData(trackCode: string): TrackData | undefined {
+  return trackDatabase.get(trackCode.toUpperCase())
+}
+
+/**
+ * Get post position bias data for a specific track, distance, and surface
+ * Returns bias data or undefined if not available
+ */
+export function getPostPositionBias(
+  trackCode: string,
+  distance: string,
+  surface: 'dirt' | 'turf' | 'synthetic'
+): PostPositionBias | undefined {
+  const track = getTrackData(trackCode)
+  if (!track) return undefined
+
+  const furlongs = parseDistanceToFurlongs(distance)
+  const category = getDistanceCategory(furlongs)
+
+  // Get biases for the surface
+  let biases: PostPositionBias[] | undefined
+  if (surface === 'turf') {
+    biases = track.postPositionBias.turf
+  } else {
+    // dirt and synthetic use dirt biases
+    biases = track.postPositionBias.dirt
+  }
+
+  if (!biases) return undefined
+
+  // Find matching distance category
+  return biases.find((b) => b.distance === category)
+}
+
+/**
+ * Get speed bias data for a specific track and surface
+ */
+export function getSpeedBias(
+  trackCode: string,
+  surface: 'dirt' | 'turf' | 'synthetic'
+): SpeedBias | undefined {
+  const track = getTrackData(trackCode)
+  if (!track) return undefined
+
+  // For synthetic, try to find synthetic first, then fall back to dirt
+  const surfaceToFind = surface === 'synthetic' ? 'dirt' : surface
+
+  return track.speedBias.find((b) => b.surface === surfaceToFind)
+}
+
+/**
+ * Calculate post position score adjustment based on track bias
+ * Returns a multiplier (0.5 to 1.5) to adjust the base post position score
+ */
+export function getPostPositionBiasMultiplier(
+  trackCode: string,
+  distance: string,
+  surface: 'dirt' | 'turf' | 'synthetic',
+  postPosition: number
+): { multiplier: number; reasoning: string } {
+  const bias = getPostPositionBias(trackCode, distance, surface)
+
+  if (!bias) {
+    return {
+      multiplier: 1.0,
+      reasoning: 'No track-specific data available'
+    }
+  }
+
+  const postIndex = postPosition - 1
+
+  // Check if post position is in the win percentage array
+  if (postIndex < 0 || postIndex >= bias.winPercentByPost.length) {
+    return {
+      multiplier: 0.8, // Outside posts get penalty
+      reasoning: 'Outside post at this track'
+    }
+  }
+
+  const winPct = bias.winPercentByPost[postIndex]
+  const avgWinPct = 100 / bias.winPercentByPost.length // Fair share
+
+  // Calculate multiplier based on how much better/worse than average
+  // A post with 16% win rate vs 10% average gets a 1.6 multiplier
+  // But we cap it to reasonable bounds
+  let multiplier = winPct / avgWinPct
+  multiplier = Math.max(0.5, Math.min(1.5, multiplier))
+
+  // Check if this is a favored post
+  const isFavored = bias.favoredPosts.includes(postPosition)
+
+  let reasoning: string
+  if (isFavored) {
+    reasoning = `Favored post ${postPosition} at ${trackCode} (${bias.biasDescription})`
+  } else if (multiplier >= 1.0) {
+    reasoning = `Post ${postPosition} performs average or better at ${trackCode}`
+  } else {
+    reasoning = `Post ${postPosition} historically disadvantaged at ${trackCode}`
+  }
+
+  return { multiplier, reasoning }
+}
+
+/**
+ * Get a summary of track biases for display in UI
+ */
+export function getTrackBiasSummary(
+  trackCode: string,
+  distance: string,
+  surface: 'dirt' | 'turf' | 'synthetic'
+): TrackBiasSummary {
+  const track = getTrackData(trackCode)
+
+  if (!track) {
+    return {
+      trackCode: trackCode.toUpperCase(),
+      trackName: trackCode.toUpperCase(),
+      speedBiasPercent: 50,
+      speedBiasDescription: 'Track data not available',
+      favoredPostsDescription: 'No data',
+      isDataAvailable: false
+    }
+  }
+
+  const speedBias = getSpeedBias(trackCode, surface)
+  const postBias = getPostPositionBias(trackCode, distance, surface)
+
+  return {
+    trackCode: track.code,
+    trackName: track.name,
+    speedBiasPercent: speedBias?.earlySpeedWinRate ?? 50,
+    speedBiasDescription: speedBias?.description ?? 'No speed data',
+    favoredPostsDescription: postBias
+      ? `Posts ${postBias.favoredPosts.join('-')} favored`
+      : 'No post data',
+    isDataAvailable: true
+  }
+}
+
+/**
+ * Check if track intelligence is available for a given track
+ */
+export function isTrackIntelligenceAvailable(trackCode: string): boolean {
+  return hasTrackData(trackCode)
+}


### PR DESCRIPTION
- Create track schema with interfaces for track measurements, post position bias, speed bias, surface characteristics, and seasonal patterns
- Add sample data for Santa Anita (SA), Gulfstream (GP), and Churchill Downs (CD) with realistic bias statistics
- Implement trackIntelligence service with functions to retrieve track data, post position bias, and speed bias by track code
- Update scoring engine to use track-specific post position bias multipliers when track data is available
- Add track bias display in race header showing speed bias percentage and favored posts with tooltip for detailed information
- Style track bias chips with color coding (amber for speed, blue for posts) and animated tooltip