### PR TITLE
Create horse detail modal component

### DIFF
--- a/src/components/HorseDetailModal.tsx
+++ b/src/components/HorseDetailModal.tsx
@@ -1,0 +1,509 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import type { HorseEntry, RaceHeader } from '../types/drf'
+import type { HorseScore } from '../lib/scoring'
+import { SCORE_LIMITS, getScoreColor } from '../lib/scoring'
+
+interface HorseDetailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  horse: HorseEntry
+  score: HorseScore
+  raceHeader: RaceHeader
+  currentOdds: string
+  predictedPosition: number
+  totalHorses: number
+}
+
+// Material Icon component
+function Icon({ name, className = '' }: { name: string; className?: string }) {
+  return (
+    <span className={`material-icons ${className}`} aria-hidden="true">
+      {name}
+    </span>
+  )
+}
+
+// Progress bar component for score visualization
+interface ScoreProgressProps {
+  value: number
+  max: number
+  color: string
+}
+
+function ScoreProgress({ value, max, color }: ScoreProgressProps) {
+  const percentage = Math.min((value / max) * 100, 100)
+
+  return (
+    <div className="score-progress-container">
+      <div className="score-progress-bar">
+        <div
+          className="score-progress-fill"
+          style={{
+            width: `${percentage}%`,
+            backgroundColor: color,
+          }}
+        />
+      </div>
+      <span className="score-progress-value" style={{ color }}>
+        {value}/{max}
+      </span>
+    </div>
+  )
+}
+
+// Category card component
+interface CategoryCardProps {
+  icon: string
+  title: string
+  score: number
+  maxScore: number
+  details: React.ReactNode
+  isExpanded: boolean
+  onToggle: () => void
+}
+
+function CategoryCard({ icon, title, score, maxScore, details, isExpanded, onToggle }: CategoryCardProps) {
+  const scoreColor = score >= maxScore * 0.7 ? '#36d1da' :
+                     score >= maxScore * 0.5 ? '#19abb5' : '#888888'
+
+  return (
+    <div className={`category-card ${isExpanded ? 'expanded' : ''}`}>
+      <button type="button" className="category-card-header" onClick={onToggle}>
+        <div className="category-card-left">
+          <Icon name={icon} className="category-icon" />
+          <span className="category-title">{title}</span>
+        </div>
+        <div className="category-card-right">
+          <div className="category-score-badge" style={{
+            backgroundColor: `${scoreColor}20`,
+            color: scoreColor,
+            borderColor: `${scoreColor}40`
+          }}>
+            {score}
+          </div>
+          <Icon name={isExpanded ? 'expand_less' : 'expand_more'} className="category-expand-icon" />
+        </div>
+      </button>
+      {isExpanded && (
+        <div className="category-card-content">
+          <ScoreProgress value={score} max={maxScore} color={scoreColor} />
+          <div className="category-details">
+            {details}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Key factor bullet
+function KeyFactor({ icon, text, type = 'neutral' }: { icon: string; text: string; type?: 'strength' | 'weakness' | 'neutral' }) {
+  const colorClass = type === 'strength' ? 'factor-strength' :
+                     type === 'weakness' ? 'factor-weakness' : 'factor-neutral'
+
+  return (
+    <div className={`key-factor ${colorClass}`}>
+      <Icon name={icon} className="factor-icon" />
+      <span className="factor-text">{text}</span>
+    </div>
+  )
+}
+
+export function HorseDetailModal({
+  isOpen,
+  onClose,
+  horse,
+  score,
+  raceHeader,
+  currentOdds,
+  predictedPosition,
+  totalHorses,
+}: HorseDetailModalProps) {
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set(['connections']))
+  const [isAnimating, setIsAnimating] = useState(false)
+
+  // Handle modal animation
+  useEffect(() => {
+    if (isOpen) {
+      setIsAnimating(true)
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
+
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [isOpen])
+
+  // Handle escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleEscape)
+    return () => window.removeEventListener('keydown', handleEscape)
+  }, [isOpen, onClose])
+
+  const toggleCategory = useCallback((category: string) => {
+    setExpandedCategories(prev => {
+      const newSet = new Set(prev)
+      if (newSet.has(category)) {
+        newSet.delete(category)
+      } else {
+        newSet.add(category)
+      }
+      return newSet
+    })
+  }, [])
+
+  // Calculate win probability based on position and score
+  const winProbability = useMemo(() => {
+    if (score.isScratched) return 0
+    // Simple probability estimation based on score and field size
+    const scoreRatio = score.total / SCORE_LIMITS.total
+    const positionBonus = predictedPosition === 1 ? 0.15 :
+                          predictedPosition === 2 ? 0.08 :
+                          predictedPosition === 3 ? 0.04 : 0
+    const fieldSizeAdjust = Math.min(0.5, 1 / totalHorses)
+    const prob = Math.min(0.65, Math.max(0.02, scoreRatio * 0.4 + positionBonus + fieldSizeAdjust))
+    return Math.round(prob * 100)
+  }, [score, predictedPosition, totalHorses])
+
+  // Generate key factors
+  const keyFactors = useMemo(() => {
+    const factors: { icon: string; text: string; type: 'strength' | 'weakness' | 'neutral' }[] = []
+    const b = score.breakdown
+
+    // Connections analysis
+    if (b.connections.total >= SCORE_LIMITS.connections * 0.8) {
+      factors.push({ icon: 'stars', text: 'Elite trainer/jockey combo', type: 'strength' })
+    } else if (b.connections.total >= SCORE_LIMITS.connections * 0.6) {
+      factors.push({ icon: 'person', text: 'Solid connections', type: 'neutral' })
+    }
+
+    // Post position analysis
+    if (b.postPosition.trackBiasApplied) {
+      if (b.postPosition.total >= SCORE_LIMITS.postPosition * 0.7) {
+        factors.push({ icon: 'trending_up', text: 'Favorable post with track bias', type: 'strength' })
+      } else if (b.postPosition.total < SCORE_LIMITS.postPosition * 0.3) {
+        factors.push({ icon: 'trending_down', text: 'Disadvantaged post position', type: 'weakness' })
+      }
+    }
+
+    // Speed figure / odds analysis
+    if (b.speedFigure.total >= SCORE_LIMITS.speedFigure * 0.8) {
+      factors.push({ icon: 'bolt', text: 'Strong public choice (low odds)', type: 'strength' })
+    } else if (b.speedFigure.total < SCORE_LIMITS.speedFigure * 0.3) {
+      factors.push({ icon: 'trending_flat', text: 'Longshot - lower public confidence', type: 'weakness' })
+    }
+
+    // Pace analysis
+    if (b.pace.total >= SCORE_LIMITS.pace * 0.7) {
+      factors.push({ icon: 'speed', text: 'Good pace scenario fit', type: 'strength' })
+    }
+
+    // Form analysis
+    if (b.form.total >= SCORE_LIMITS.form * 0.7) {
+      factors.push({ icon: 'fitness_center', text: 'Sharp form', type: 'strength' })
+    } else if (b.form.total < SCORE_LIMITS.form * 0.4) {
+      factors.push({ icon: 'schedule', text: 'Form concerns', type: 'weakness' })
+    }
+
+    return factors
+  }, [score.breakdown])
+
+  // Determine running style based on pace score
+  const runningStyle = useMemo(() => {
+    const paceScore = score.breakdown.pace.total
+    if (paceScore >= 28) return { style: 'Presser/Stalker', desc: 'Can rate off the pace and make a timely move' }
+    if (paceScore >= 24) return { style: 'Speed', desc: 'Prefers to be on or near the lead' }
+    return { style: 'Closer', desc: 'Comes from off the pace in the stretch' }
+  }, [score.breakdown.pace.total])
+
+  if (!isOpen) return null
+
+  const scoreColor = getScoreColor(score.total, score.isScratched)
+  const ordinal = (n: number) => {
+    const s = ['th', 'st', 'nd', 'rd']
+    const v = n % 100
+    return n + (s[(v - 20) % 10] || s[v] || s[0])
+  }
+
+  return (
+    <div
+      className={`modal-overlay ${isAnimating ? 'animate-in' : ''}`}
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="horse-modal-title"
+    >
+      <div className="horse-modal">
+        {/* Close button */}
+        <button
+          type="button"
+          className="modal-close-btn"
+          onClick={onClose}
+          aria-label="Close modal"
+        >
+          <Icon name="close" />
+        </button>
+
+        {/* Header Section */}
+        <header className="modal-header">
+          <div className="modal-header-top">
+            <div className="horse-identity">
+              <div className="horse-badges">
+                <span className="program-badge">#{horse.programNumber}</span>
+                <span className="post-badge">PP{horse.postPosition}</span>
+              </div>
+              <h2 id="horse-modal-title" className="horse-name-large">{horse.horseName}</h2>
+            </div>
+
+            <div className="score-display-large">
+              <div
+                className="score-circle"
+                style={{
+                  borderColor: scoreColor,
+                  color: scoreColor,
+                  boxShadow: `0 0 20px ${scoreColor}30`
+                }}
+              >
+                <span className="score-value">{score.isScratched ? '—' : score.total}</span>
+                <span className="score-max">/{SCORE_LIMITS.total}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="modal-header-stats">
+            <div className="stat-pill">
+              <Icon name="emoji_events" className="stat-icon" />
+              <span className="stat-label">Predicted</span>
+              <span className="stat-value">{ordinal(predictedPosition)}</span>
+            </div>
+            <div className="stat-pill highlight">
+              <Icon name="percent" className="stat-icon" />
+              <span className="stat-label">Win Prob</span>
+              <span className="stat-value">{winProbability}%</span>
+            </div>
+            <div className="stat-pill">
+              <Icon name="paid" className="stat-icon" />
+              <span className="stat-label">Odds</span>
+              <span className="stat-value">{currentOdds}</span>
+            </div>
+          </div>
+        </header>
+
+        {/* Scrollable Content */}
+        <div className="modal-content">
+          {/* Score Breakdown Section */}
+          <section className="modal-section">
+            <h3 className="section-title-modal">
+              <Icon name="analytics" className="section-icon-modal" />
+              Score Breakdown
+            </h3>
+
+            <div className="category-cards">
+              <CategoryCard
+                icon="people"
+                title="Connections"
+                score={score.breakdown.connections.total}
+                maxScore={SCORE_LIMITS.connections}
+                isExpanded={expandedCategories.has('connections')}
+                onToggle={() => toggleCategory('connections')}
+                details={
+                  <div className="breakdown-details">
+                    <div className="breakdown-row">
+                      <span className="breakdown-label">Trainer Score</span>
+                      <span className="breakdown-value">{score.breakdown.connections.trainer}/25</span>
+                    </div>
+                    <div className="breakdown-row">
+                      <span className="breakdown-label">Jockey Score</span>
+                      <span className="breakdown-value">{score.breakdown.connections.jockey}/25</span>
+                    </div>
+                    <div className="breakdown-note">
+                      Combined trainer + jockey rating
+                    </div>
+                  </div>
+                }
+              />
+
+              <CategoryCard
+                icon="grid_view"
+                title="Post Position / Bias"
+                score={score.breakdown.postPosition.total}
+                maxScore={SCORE_LIMITS.postPosition}
+                isExpanded={expandedCategories.has('postPosition')}
+                onToggle={() => toggleCategory('postPosition')}
+                details={
+                  <div className="breakdown-details">
+                    <div className="breakdown-row">
+                      <span className="breakdown-label">Post Position</span>
+                      <span className="breakdown-value">{horse.postPosition}</span>
+                    </div>
+                    <div className="breakdown-row">
+                      <span className="breakdown-label">Track Bias Applied</span>
+                      <span className="breakdown-value">
+                        {score.breakdown.postPosition.trackBiasApplied ?
+                          <Icon name="check_circle" className="text-sm text-accent" /> :
+                          <Icon name="remove_circle_outline" className="text-sm" />
+                        }
+                      </span>
+                    </div>
+                    <div className="breakdown-note">
+                      {score.breakdown.postPosition.reasoning}
+                    </div>
+                  </div>
+                }
+              />
+
+              <CategoryCard
+                icon="speed"
+                title="Speed Figures / Class"
+                score={score.breakdown.speedFigure.total}
+                maxScore={SCORE_LIMITS.speedFigure}
+                isExpanded={expandedCategories.has('speedFigure')}
+                onToggle={() => toggleCategory('speedFigure')}
+                details={
+                  <div className="breakdown-details">
+                    <div className="breakdown-note">
+                      {score.breakdown.speedFigure.reasoning}
+                    </div>
+                    <div className="breakdown-hint">
+                      Based on current odds as class indicator
+                    </div>
+                  </div>
+                }
+              />
+
+              <CategoryCard
+                icon="fitness_center"
+                title="Form / Conditioning"
+                score={score.breakdown.form.total}
+                maxScore={SCORE_LIMITS.form}
+                isExpanded={expandedCategories.has('form')}
+                onToggle={() => toggleCategory('form')}
+                details={
+                  <div className="breakdown-details">
+                    <div className="breakdown-note">
+                      {score.breakdown.form.reasoning}
+                    </div>
+                  </div>
+                }
+              />
+
+              <CategoryCard
+                icon="build"
+                title="Equipment / Medication"
+                score={score.breakdown.equipment.total}
+                maxScore={SCORE_LIMITS.equipment}
+                isExpanded={expandedCategories.has('equipment')}
+                onToggle={() => toggleCategory('equipment')}
+                details={
+                  <div className="breakdown-details">
+                    <div className="breakdown-note">
+                      {score.breakdown.equipment.reasoning}
+                    </div>
+                  </div>
+                }
+              />
+
+              <CategoryCard
+                icon="timeline"
+                title="Pace / Tactical"
+                score={score.breakdown.pace.total}
+                maxScore={SCORE_LIMITS.pace}
+                isExpanded={expandedCategories.has('pace')}
+                onToggle={() => toggleCategory('pace')}
+                details={
+                  <div className="breakdown-details">
+                    <div className="breakdown-row">
+                      <span className="breakdown-label">Running Style</span>
+                      <span className="breakdown-value">{runningStyle.style}</span>
+                    </div>
+                    <div className="breakdown-note">
+                      {score.breakdown.pace.reasoning}
+                    </div>
+                  </div>
+                }
+              />
+            </div>
+          </section>
+
+          {/* Key Factors Section */}
+          <section className="modal-section">
+            <h3 className="section-title-modal">
+              <Icon name="lightbulb" className="section-icon-modal" />
+              Key Factors
+            </h3>
+
+            <div className="key-factors-list">
+              {keyFactors.length > 0 ? (
+                keyFactors.map((factor, i) => (
+                  <KeyFactor key={i} icon={factor.icon} text={factor.text} type={factor.type} />
+                ))
+              ) : (
+                <KeyFactor icon="info" text="Average profile - no standout factors" type="neutral" />
+              )}
+            </div>
+
+            <div className="pace-scenario-box">
+              <div className="pace-scenario-header">
+                <Icon name="directions_run" className="pace-scenario-icon" />
+                <span>Running Style Analysis</span>
+              </div>
+              <div className="pace-scenario-content">
+                <div className="running-style-badge">{runningStyle.style}</div>
+                <p className="pace-scenario-desc">{runningStyle.desc}</p>
+              </div>
+            </div>
+          </section>
+
+          {/* DRF Data Section */}
+          <section className="modal-section">
+            <h3 className="section-title-modal">
+              <Icon name="description" className="section-icon-modal" />
+              Race Data
+            </h3>
+
+            <div className="drf-data-grid">
+              <div className="drf-data-item">
+                <span className="drf-label">Trainer</span>
+                <span className="drf-value">{horse.trainerName}</span>
+              </div>
+              <div className="drf-data-item">
+                <span className="drf-label">Jockey</span>
+                <span className="drf-value">{horse.jockeyName}</span>
+              </div>
+              <div className="drf-data-item">
+                <span className="drf-label">M/L Odds</span>
+                <span className="drf-value highlight">{horse.morningLineOdds}</span>
+              </div>
+              <div className="drf-data-item">
+                <span className="drf-label">Current Odds</span>
+                <span className="drf-value highlight">{currentOdds}</span>
+              </div>
+              <div className="drf-data-item">
+                <span className="drf-label">Distance</span>
+                <span className="drf-value">{raceHeader.distance}</span>
+              </div>
+              <div className="drf-data-item">
+                <span className="drf-label">Surface</span>
+                <span className="drf-value capitalize">{raceHeader.surface}</span>
+              </div>
+            </div>
+
+            <div className="drf-race-context">
+              <Icon name="location_on" className="text-primary" />
+              <span>{raceHeader.trackCode} - Race {raceHeader.raceNumber}</span>
+              <span className="drf-date">{raceHeader.raceDate}</span>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1056,3 +1056,689 @@ body {
     gap: 0.375rem;
   }
 }
+
+/* ============================================
+   Clickable Row Styles
+   ============================================ */
+
+.race-row-clickable {
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.1s ease;
+}
+
+.race-row-clickable:hover {
+  background-color: rgba(25, 171, 181, 0.08);
+}
+
+.race-row-clickable:focus {
+  outline: none;
+  background-color: rgba(25, 171, 181, 0.12);
+  box-shadow: inset 0 0 0 2px rgba(25, 171, 181, 0.3);
+}
+
+.race-row-clickable:active {
+  transform: scale(0.995);
+}
+
+.row-chevron-cell {
+  width: 40px;
+  text-align: center;
+  padding-right: 0.5rem !important;
+}
+
+.row-chevron {
+  font-size: 1.25rem;
+  color: rgba(238, 239, 241, 0.3);
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease, transform 0.15s ease;
+}
+
+.race-row-clickable:hover .row-chevron {
+  opacity: 1;
+  color: var(--color-primary);
+  transform: translateX(2px);
+}
+
+/* Mobile card clickable styles */
+.mobile-card-clickable {
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.1s ease, border-color 0.15s ease;
+}
+
+.mobile-card-clickable:hover {
+  background-color: rgba(25, 171, 181, 0.08);
+  border-color: rgba(25, 171, 181, 0.3);
+}
+
+.mobile-card-clickable:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px rgba(25, 171, 181, 0.2);
+}
+
+.mobile-card-clickable:active {
+  transform: scale(0.98);
+}
+
+.mobile-card-chevron {
+  font-size: 1.25rem;
+  color: rgba(238, 239, 241, 0.4);
+  transition: color 0.15s ease, transform 0.15s ease;
+}
+
+.mobile-card-clickable:hover .mobile-card-chevron {
+  color: var(--color-primary);
+  transform: translateX(2px);
+}
+
+/* ============================================
+   Horse Detail Modal Styles
+   ============================================ */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.modal-overlay.animate-in {
+  opacity: 1;
+}
+
+.horse-modal {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  max-height: 90vh;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 20px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transform: scale(0.95) translateY(10px);
+  animation: modal-slide-in 0.25s ease forwards;
+}
+
+@keyframes modal-slide-in {
+  to {
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* Full screen on mobile */
+@media (max-width: 640px) {
+  .horse-modal {
+    max-width: none;
+    max-height: none;
+    height: 100%;
+    border-radius: 0;
+    animation: modal-slide-up 0.3s ease forwards;
+  }
+
+  @keyframes modal-slide-up {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+}
+
+/* Close button */
+.modal-close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background-color: var(--color-surface-variant);
+  border: 1px solid var(--color-outline);
+  border-radius: 50%;
+  color: rgba(238, 239, 241, 0.7);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.modal-close-btn:hover {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.modal-close-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(25, 171, 181, 0.3);
+}
+
+/* Modal Header */
+.modal-header {
+  padding: 1.5rem;
+  background: linear-gradient(180deg, var(--color-surface-variant) 0%, var(--color-surface) 100%);
+  border-bottom: 1px solid var(--color-outline);
+}
+
+.modal-header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.horse-identity {
+  flex: 1;
+  min-width: 0;
+}
+
+.horse-badges {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.program-badge,
+.post-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.625rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(238, 239, 241, 0.7);
+}
+
+.program-badge {
+  color: var(--color-primary);
+  border-color: rgba(25, 171, 181, 0.3);
+  background-color: rgba(25, 171, 181, 0.1);
+}
+
+.horse-name-large {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-on-surface);
+  line-height: 1.2;
+}
+
+@media (max-width: 640px) {
+  .horse-name-large {
+    font-size: 1.25rem;
+  }
+}
+
+/* Score Circle */
+.score-display-large {
+  flex-shrink: 0;
+}
+
+.score-circle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 80px;
+  border: 3px solid;
+  border-radius: 50%;
+  background-color: var(--color-surface);
+}
+
+@media (max-width: 640px) {
+  .score-circle {
+    width: 64px;
+    height: 64px;
+    border-width: 2px;
+  }
+}
+
+.score-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+@media (max-width: 640px) {
+  .score-value {
+    font-size: 1.375rem;
+  }
+}
+
+.score-max {
+  font-size: 0.75rem;
+  color: rgba(238, 239, 241, 0.5);
+  margin-top: 0.125rem;
+}
+
+/* Header Stats */
+.modal-header-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.stat-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-outline);
+  border-radius: 20px;
+  font-size: 0.8125rem;
+}
+
+.stat-pill.highlight {
+  background-color: rgba(25, 171, 181, 0.1);
+  border-color: rgba(25, 171, 181, 0.3);
+}
+
+.stat-icon {
+  font-size: 1rem;
+  color: var(--color-primary);
+}
+
+.stat-label {
+  color: rgba(238, 239, 241, 0.5);
+}
+
+.stat-value {
+  font-weight: 600;
+  color: var(--color-on-surface);
+}
+
+.stat-pill.highlight .stat-value {
+  color: var(--color-primary);
+}
+
+/* Modal Content */
+.modal-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.modal-section {
+  margin-bottom: 1.5rem;
+}
+
+.modal-section:last-child {
+  margin-bottom: 0;
+}
+
+.section-title-modal {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(238, 239, 241, 0.6);
+}
+
+.section-icon-modal {
+  font-size: 1.125rem;
+  color: var(--color-primary);
+}
+
+/* Category Cards */
+.category-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.category-card {
+  background-color: var(--color-surface-variant);
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.15s ease;
+}
+
+.category-card.expanded {
+  border-color: rgba(25, 171, 181, 0.3);
+}
+
+.category-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.category-card-header:hover {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.category-card-left {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.category-icon {
+  font-size: 1.125rem;
+  color: rgba(238, 239, 241, 0.5);
+}
+
+.category-card.expanded .category-icon {
+  color: var(--color-primary);
+}
+
+.category-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-on-surface);
+}
+
+.category-card-right {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.category-score-badge {
+  min-width: 2.5rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 6px;
+  border: 1px solid;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.category-expand-icon {
+  font-size: 1.25rem;
+  color: rgba(238, 239, 241, 0.4);
+  transition: transform 0.2s ease;
+}
+
+/* Category Card Content */
+.category-card-content {
+  padding: 0 1rem 1rem;
+  border-top: 1px solid var(--color-outline);
+  animation: card-content-fade-in 0.2s ease;
+}
+
+@keyframes card-content-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Score Progress */
+.score-progress-container {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 0;
+}
+
+.score-progress-bar {
+  flex: 1;
+  height: 8px;
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.score-progress-fill {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.score-progress-value {
+  min-width: 45px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Category Details */
+.category-details {
+  padding-top: 0.5rem;
+}
+
+.breakdown-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.375rem 0;
+}
+
+.breakdown-label {
+  font-size: 0.8125rem;
+  color: rgba(238, 239, 241, 0.6);
+}
+
+.breakdown-value {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-on-surface);
+  font-variant-numeric: tabular-nums;
+}
+
+.breakdown-note {
+  font-size: 0.75rem;
+  color: rgba(238, 239, 241, 0.5);
+  font-style: italic;
+  padding-top: 0.25rem;
+  line-height: 1.4;
+}
+
+.breakdown-hint {
+  font-size: 0.6875rem;
+  color: rgba(238, 239, 241, 0.4);
+  padding-top: 0.375rem;
+}
+
+.text-accent {
+  color: var(--color-primary);
+}
+
+/* Key Factors */
+.key-factors-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.key-factor {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.625rem 0.875rem;
+  background-color: var(--color-surface-variant);
+  border: 1px solid var(--color-outline);
+  border-radius: 10px;
+}
+
+.factor-icon {
+  font-size: 1.125rem;
+}
+
+.factor-text {
+  font-size: 0.875rem;
+  color: var(--color-on-surface);
+}
+
+.factor-strength .factor-icon {
+  color: #36d1da;
+}
+
+.factor-strength {
+  border-color: rgba(54, 209, 218, 0.3);
+  background-color: rgba(54, 209, 218, 0.08);
+}
+
+.factor-weakness .factor-icon {
+  color: #f59e0b;
+}
+
+.factor-weakness {
+  border-color: rgba(245, 158, 11, 0.3);
+  background-color: rgba(245, 158, 11, 0.08);
+}
+
+.factor-neutral .factor-icon {
+  color: rgba(238, 239, 241, 0.5);
+}
+
+/* Pace Scenario Box */
+.pace-scenario-box {
+  background-color: var(--color-surface-variant);
+  border: 1px solid var(--color-outline);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.pace-scenario-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background-color: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid var(--color-outline);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: rgba(238, 239, 241, 0.7);
+}
+
+.pace-scenario-icon {
+  font-size: 1.125rem;
+  color: var(--color-primary);
+}
+
+.pace-scenario-content {
+  padding: 0.875rem 1rem;
+}
+
+.running-style-badge {
+  display: inline-block;
+  padding: 0.375rem 0.75rem;
+  background-color: rgba(25, 171, 181, 0.15);
+  border: 1px solid rgba(25, 171, 181, 0.3);
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  margin-bottom: 0.5rem;
+}
+
+.pace-scenario-desc {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: rgba(238, 239, 241, 0.6);
+  line-height: 1.5;
+}
+
+/* DRF Data Grid */
+.drf-data-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+@media (min-width: 480px) {
+  .drf-data-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.drf-data-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.625rem;
+  background-color: var(--color-surface-variant);
+  border: 1px solid var(--color-outline);
+  border-radius: 8px;
+}
+
+.drf-label {
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(238, 239, 241, 0.4);
+}
+
+.drf-value {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-on-surface);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.drf-value.highlight {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.drf-value.capitalize {
+  text-transform: capitalize;
+}
+
+.drf-race-context {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  background-color: rgba(25, 171, 181, 0.08);
+  border: 1px solid rgba(25, 171, 181, 0.2);
+  border-radius: 8px;
+  font-size: 0.8125rem;
+  color: rgba(238, 239, 241, 0.7);
+}
+
+.drf-race-context .text-primary {
+  color: var(--color-primary);
+}
+
+.drf-date {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: rgba(238, 239, 241, 0.4);
+}


### PR DESCRIPTION
- Create HorseDetailModal component with Material 3 dark theme styling
- Display horse name, program number, post position, score, predicted finish
- Add expandable score breakdown cards for all 6 scoring categories
- Show key factors analysis (strengths/weaknesses) with icons
- Include running style and pace scenario explanations
- Display DRF raw data (trainer, jockey, odds, race info)
- Make table rows clickable with hover state and chevron indicator
- Full-screen drawer on mobile, centered modal on desktop
- Add smooth slide-in/slide-up animations
- Color-coded score badges and progress bars for each category