### PR TITLE
Restructure UI to overview-first navigation

### DIFF
--- a/MASTER_CONTEXT.md
+++ b/MASTER_CONTEXT.md
@@ -449,6 +449,26 @@ Unknown tracks get:
 
 ## Application Structure
 
+### Overview-First Navigation
+
+**User Flow:** Upload DRF file → Race Overview (all races) → Click race → Race Detail → Back to Overview
+
+**Primary View: Race Overview**
+- Displays ALL races from parsed DRF file as cards
+- Each card shows: race number, distance, surface, class, confidence badge
+- Confidence badges use color-coded indicators (High/Moderate/Low)
+- Tier 1 picks highlighted with accent styling
+- Click any race card to drill into details
+
+**Secondary View: Race Detail**
+- Full horse-by-horse analysis
+- Scoring breakdowns, betting recommendations
+- Controls for scratches, odds updates, track conditions
+- Back button + Escape key returns to Overview
+- Confidence recalculates on changes
+
+### Component Architecture
+
 ```
 src/
 ├── main.tsx
@@ -456,9 +476,11 @@ src/
 ├── index.css
 │
 ├── components/
-│   ├── Dashboard.tsx
+│   ├── Dashboard.tsx          # View orchestrator (overview vs detail)
+│   ├── RaceOverview.tsx       # All races grid with confidence badges
+│   ├── RaceDetail.tsx         # Single race deep dive (wraps existing components)
 │   ├── FileUpload.tsx
-│   ├── RaceTable.tsx
+│   ├── RaceTable.tsx          # Horse table within detail view
 │   ├── RaceControls.tsx
 │   ├── BettingRecommendations.tsx
 │   ├── HorseDetailModal.tsx
@@ -490,6 +512,7 @@ src/
 │   ├── drfParser.ts
 │   ├── drfWorker.ts
 │   ├── validation.ts
+│   ├── confidence.ts          # Shared confidence utilities
 │   ├── scoring/
 │   │   ├── index.ts
 │   │   ├── connections.ts
@@ -534,6 +557,7 @@ src/
 10. **Atomic prompts** — One focused task per Claude Code session
 11. **Test before merge** — npm test passes, manual verification done
 12. **No App Store** — PWA only, direct web access
+13. **Overview-first navigation** — Users see all races with confidence before drilling into details
 
 ---
 
@@ -583,13 +607,16 @@ src/
 
 ### Phase 6: User Interface
 - [ ] File upload flow
-- [ ] Race selection interface
+- [ ] Race Overview screen (all races with confidence badges)
+- [ ] Race Detail screen (single race deep dive)
+- [ ] View management (overview ↔ detail navigation)
 - [ ] Horse table/cards (responsive)
 - [ ] Scoring breakdown panels
 - [ ] Betting recommendations display
 - [ ] Horse detail modal
 - [ ] Scratch/conditions controls
 - [ ] Real-time recalculation feedback
+- [ ] Keyboard navigation (Escape returns to overview)
 
 ### Phase 7: Enterprise Scaffolding
 - [ ] Auth service abstraction

--- a/src/components/CalculationStatus.tsx
+++ b/src/components/CalculationStatus.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useState } from 'react'
 import type { CalculationState } from '../hooks/useRaceState'
+import { getConfidenceColor, getConfidenceLabel } from '../lib/confidence'
 
 interface CalculationStatusProps {
   calculationState: CalculationState
@@ -26,21 +27,6 @@ function formatTimestamp(timestamp: number | null): string {
   if (diff < 60000) return `${Math.floor(diff / 1000)}s ago`
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`
   return new Date(timestamp).toLocaleTimeString()
-}
-
-function getConfidenceColor(confidence: number): string {
-  if (confidence >= 75) return '#36d1da'
-  if (confidence >= 50) return '#19abb5'
-  if (confidence >= 25) return '#f59e0b'
-  return '#888888'
-}
-
-function getConfidenceLabel(confidence: number): string {
-  if (confidence >= 80) return 'Very High'
-  if (confidence >= 65) return 'High'
-  if (confidence >= 50) return 'Moderate'
-  if (confidence >= 35) return 'Low'
-  return 'Very Low'
 }
 
 export const CalculationStatus = memo(function CalculationStatus({

--- a/src/components/RaceDetail.tsx
+++ b/src/components/RaceDetail.tsx
@@ -1,0 +1,134 @@
+import { memo, useEffect } from 'react'
+import { motion } from 'framer-motion'
+import type { ParsedRace } from '../types/drf'
+import type { UseRaceStateReturn } from '../hooks/useRaceState'
+import type { UseBankrollReturn } from '../hooks/useBankroll'
+import { RaceTable } from './RaceTable'
+import {
+  getConfidenceColor,
+  getConfidenceLabel,
+  getConfidenceBgColor,
+  getConfidenceBorderColor,
+} from '../lib/confidence'
+
+interface RaceDetailProps {
+  race: ParsedRace
+  confidence: number
+  raceState: UseRaceStateReturn
+  bankroll: UseBankrollReturn
+  onBack: () => void
+  onOpenBankrollSettings: () => void
+}
+
+// Material Icon component
+function Icon({ name, className = '' }: { name: string; className?: string }) {
+  return (
+    <span className={`material-icons ${className}`} aria-hidden="true">
+      {name}
+    </span>
+  )
+}
+
+// Confidence badge component
+interface ConfidenceBadgeProps {
+  confidence: number
+}
+
+const ConfidenceBadge = memo(function ConfidenceBadge({
+  confidence,
+}: ConfidenceBadgeProps) {
+  const color = getConfidenceColor(confidence)
+  const label = getConfidenceLabel(confidence)
+  const bgColor = getConfidenceBgColor(confidence)
+  const borderColor = getConfidenceBorderColor(confidence)
+
+  return (
+    <div
+      className="confidence-badge confidence-badge-small"
+      style={{
+        backgroundColor: bgColor,
+        borderColor: borderColor,
+        color: color,
+      }}
+    >
+      <span className="confidence-value tabular-nums">{confidence}%</span>
+      <span className="confidence-label">{label}</span>
+    </div>
+  )
+})
+
+export const RaceDetail = memo(function RaceDetail({
+  race,
+  confidence,
+  raceState,
+  bankroll,
+  onBack,
+  onOpenBankrollSettings,
+}: RaceDetailProps) {
+  const { header } = race
+
+  // Handle Escape key to go back
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onBack()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onBack])
+
+  // Format surface nicely
+  const surfaceLabel = header.surface.charAt(0).toUpperCase() + header.surface.slice(1)
+
+  return (
+    <motion.div
+      className="race-detail"
+      initial={{ opacity: 0, x: 20 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -20 }}
+      transition={{ duration: 0.2 }}
+    >
+      {/* Header with back navigation */}
+      <div className="race-detail-header">
+        <button
+          type="button"
+          className="race-detail-back-btn"
+          onClick={onBack}
+          aria-label="Back to race overview"
+        >
+          <Icon name="arrow_back" />
+          <span>Overview</span>
+        </button>
+        <span className="race-detail-back-hint">(Esc)</span>
+
+        <div className="race-detail-info">
+          <h1 className="race-detail-title">
+            Race {header.raceNumber}
+          </h1>
+          <span className="race-detail-subtitle">
+            {header.distance} {surfaceLabel}
+            {header.classification && ` • ${header.classification}`}
+          </span>
+        </div>
+
+        <div className="race-detail-confidence">
+          <ConfidenceBadge confidence={confidence} />
+        </div>
+      </div>
+
+      {/* Race content */}
+      <div className="race-detail-content">
+        <RaceTable
+          race={race}
+          raceState={raceState}
+          bankroll={bankroll}
+          onOpenBankrollSettings={onOpenBankrollSettings}
+        />
+      </div>
+    </motion.div>
+  )
+})
+
+export default RaceDetail

--- a/src/components/RaceOverview.tsx
+++ b/src/components/RaceOverview.tsx
@@ -1,0 +1,266 @@
+import { memo, useMemo, useCallback, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import type { ParsedRace, ParsedDRFFile } from '../types/drf'
+import type { ScoredHorse } from '../lib/scoring'
+import {
+  getConfidenceColor,
+  getConfidenceLabel,
+  getConfidenceBgColor,
+  getConfidenceBorderColor,
+} from '../lib/confidence'
+import { SCORE_THRESHOLDS } from '../lib/scoring'
+
+interface RaceOverviewProps {
+  parsedData: ParsedDRFFile
+  raceConfidences: Map<number, number>
+  topHorsesByRace: Map<number, ScoredHorse[]>
+  onRaceSelect: (raceIndex: number) => void
+}
+
+// Material Icon component
+function Icon({ name, className = '' }: { name: string; className?: string }) {
+  return (
+    <span className={`material-icons ${className}`} aria-hidden="true">
+      {name}
+    </span>
+  )
+}
+
+// Confidence badge component
+interface ConfidenceBadgeProps {
+  confidence: number
+  size?: 'small' | 'normal'
+}
+
+const ConfidenceBadge = memo(function ConfidenceBadge({
+  confidence,
+  size = 'normal',
+}: ConfidenceBadgeProps) {
+  const color = getConfidenceColor(confidence)
+  const label = getConfidenceLabel(confidence)
+  const bgColor = getConfidenceBgColor(confidence)
+  const borderColor = getConfidenceBorderColor(confidence)
+
+  return (
+    <div
+      className={`confidence-badge ${size === 'small' ? 'confidence-badge-small' : ''}`}
+      style={{
+        backgroundColor: bgColor,
+        borderColor: borderColor,
+        color: color,
+      }}
+    >
+      <span className="confidence-value tabular-nums">{confidence}%</span>
+      <span className="confidence-label">{label}</span>
+    </div>
+  )
+})
+
+// Race card component
+interface RaceCardProps {
+  race: ParsedRace
+  raceIndex: number
+  confidence: number
+  topHorses: ScoredHorse[]
+  scratchedCount: number
+  onClick: () => void
+}
+
+const RaceCard = memo(function RaceCard({
+  race,
+  raceIndex,
+  confidence,
+  topHorses,
+  scratchedCount,
+  onClick,
+}: RaceCardProps) {
+  const { header, horses } = race
+  const activeCount = horses.length - scratchedCount
+
+  // Check if there's a Tier 1 pick (180+ points)
+  const hasTier1Pick = topHorses.some(h => h.score.total >= SCORE_THRESHOLDS.strong)
+
+  // Format surface nicely
+  const surfaceLabel = header.surface.charAt(0).toUpperCase() + header.surface.slice(1)
+
+  // Get race class/type abbreviation
+  const classLabel = header.classification || header.raceType || ''
+
+  return (
+    <motion.button
+      className={`race-card ${hasTier1Pick ? 'race-card-has-tier1' : ''}`}
+      onClick={onClick}
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, delay: raceIndex * 0.05 }}
+      aria-label={`Race ${header.raceNumber}: ${header.distance} ${surfaceLabel}. ${confidence}% confidence. Click to view details.`}
+    >
+      {/* Race number badge */}
+      <div className="race-card-number">
+        <span>R{header.raceNumber}</span>
+      </div>
+
+      {/* Main content */}
+      <div className="race-card-content">
+        {/* Race info row */}
+        <div className="race-card-info">
+          <div className="race-card-distance">
+            <Icon name="route" className="race-card-icon" />
+            <span>{header.distance}</span>
+          </div>
+          <div className="race-card-surface">
+            <Icon name="terrain" className="race-card-icon" />
+            <span>{surfaceLabel}</span>
+          </div>
+        </div>
+
+        {/* Class and purse */}
+        <div className="race-card-details">
+          {classLabel && (
+            <span className="race-card-class">{classLabel}</span>
+          )}
+          {header.purseFormatted && (
+            <span className="race-card-purse">{header.purseFormatted}</span>
+          )}
+        </div>
+
+        {/* Horse count */}
+        <div className="race-card-horses">
+          <Icon name="pets" className="race-card-icon" />
+          <span className="tabular-nums">
+            {activeCount}
+            {scratchedCount > 0 && (
+              <span className="race-card-scratched">/{horses.length}</span>
+            )}
+          </span>
+          <span className="race-card-horses-label">horses</span>
+        </div>
+
+        {/* Top pick preview (if available) */}
+        {topHorses.length > 0 && topHorses[0].score.total >= SCORE_THRESHOLDS.fair && (
+          <div className="race-card-top-pick">
+            <Icon name="star" className="race-card-star" />
+            <span className="race-card-top-name">
+              {topHorses[0].horse.horseName.slice(0, 12)}
+              {topHorses[0].horse.horseName.length > 12 ? '...' : ''}
+            </span>
+            <span className="race-card-top-score tabular-nums">
+              {topHorses[0].score.total}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Confidence badge */}
+      <div className="race-card-confidence">
+        <ConfidenceBadge confidence={confidence} />
+      </div>
+
+      {/* Tier 1 indicator */}
+      {hasTier1Pick && (
+        <div className="race-card-tier1-indicator" title="Tier 1 pick available">
+          <Icon name="trending_up" />
+        </div>
+      )}
+
+      {/* Click hint */}
+      <div className="race-card-chevron">
+        <Icon name="chevron_right" />
+      </div>
+    </motion.button>
+  )
+})
+
+export const RaceOverview = memo(function RaceOverview({
+  parsedData,
+  raceConfidences,
+  topHorsesByRace,
+  onRaceSelect,
+}: RaceOverviewProps) {
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    // Number keys 1-9 for quick race selection
+    const num = parseInt(e.key)
+    if (num >= 1 && num <= parsedData.races.length) {
+      onRaceSelect(num - 1)
+    }
+  }, [parsedData.races.length, onRaceSelect])
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  // Summary stats
+  const stats = useMemo(() => {
+    let totalHorses = 0
+    let tier1Races = 0
+
+    parsedData.races.forEach((race, index) => {
+      totalHorses += race.horses.length
+      const topHorses = topHorsesByRace.get(index) || []
+      if (topHorses.some(h => h.score.total >= SCORE_THRESHOLDS.strong)) {
+        tier1Races++
+      }
+    })
+
+    return { totalHorses, tier1Races }
+  }, [parsedData.races, topHorsesByRace])
+
+  return (
+    <div className="race-overview">
+      {/* Header */}
+      <div className="race-overview-header">
+        <div className="race-overview-title">
+          <Icon name="view_module" className="race-overview-icon" />
+          <h2>Race Overview</h2>
+        </div>
+        <div className="race-overview-stats">
+          <span className="race-overview-stat">
+            <span className="tabular-nums">{parsedData.races.length}</span> races
+          </span>
+          <span className="race-overview-stat-divider">•</span>
+          <span className="race-overview-stat">
+            <span className="tabular-nums">{stats.totalHorses}</span> horses
+          </span>
+          {stats.tier1Races > 0 && (
+            <>
+              <span className="race-overview-stat-divider">•</span>
+              <span className="race-overview-stat race-overview-stat-tier1">
+                <Icon name="trending_up" className="race-overview-tier1-icon" />
+                <span className="tabular-nums">{stats.tier1Races}</span> Tier 1
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Keyboard hint */}
+      <div className="race-overview-hint">
+        <Icon name="keyboard" className="race-overview-hint-icon" />
+        <span>Press 1-{Math.min(9, parsedData.races.length)} for quick access</span>
+      </div>
+
+      {/* Race grid */}
+      <div className="race-overview-grid">
+        <AnimatePresence>
+          {parsedData.races.map((race, index) => (
+            <RaceCard
+              key={index}
+              race={race}
+              raceIndex={index}
+              confidence={raceConfidences.get(index) || 0}
+              topHorses={topHorsesByRace.get(index) || []}
+              scratchedCount={0}
+              onClick={() => onRaceSelect(index)}
+            />
+          ))}
+        </AnimatePresence>
+      </div>
+    </div>
+  )
+})
+
+export default RaceOverview

--- a/src/components/RaceTable.tsx
+++ b/src/components/RaceTable.tsx
@@ -9,6 +9,7 @@ import { CalculationStatus } from './CalculationStatus'
 import { ToastContainer, useToasts } from './Toast'
 import {
   calculateRaceScores,
+  calculateRaceConfidence,
   getScoreColor,
   getScoreTier,
   SCORE_THRESHOLDS,
@@ -685,21 +686,9 @@ export function RaceTable({ race, raceState, bankroll, onOpenBankrollSettings }:
 
   // Calculate stats for CalculationStatus
   const activeHorses = scoredHorses.filter(h => !h.score.isScratched).length
+  // Use centralized confidence calculation from scoring module
   const confidenceLevel = useMemo(() => {
-    const scores = scoredHorses
-      .filter(h => !h.score.isScratched)
-      .map(h => h.score.total)
-      .sort((a, b) => b - a)
-
-    if (scores.length < 2) return 50
-
-    const topScore = scores[0]
-    const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length
-    const differential = scores.length > 1 ? ((topScore - scores[1]) / topScore) * 30 : 0
-    const qualityBonus = Math.min(20, (topScore / 240) * 25)
-    const baseConfidence = 40 + (avgScore / 240) * 30
-
-    return Math.min(100, Math.round(baseConfidence + differential + qualityBonus))
+    return calculateRaceConfidence(scoredHorses)
   }, [scoredHorses])
 
   // Handle row click to open modal

--- a/src/lib/confidence.ts
+++ b/src/lib/confidence.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared Confidence Utilities
+ *
+ * Used by:
+ * - RaceOverview.tsx (confidence badges for each race)
+ * - CalculationStatus.tsx (confidence display in race detail)
+ * - RaceTable.tsx (race confidence calculation)
+ *
+ * Confidence is calculated based on:
+ * - Data quality of horses in the race
+ * - Score separation between top picks
+ * - Quality of the top-scoring horse
+ */
+
+/**
+ * Confidence thresholds for color coding
+ */
+export const CONFIDENCE_THRESHOLDS = {
+  veryHigh: 80,
+  high: 65,
+  moderate: 50,
+  low: 35,
+} as const
+
+/**
+ * Get the color for a confidence level
+ * Uses design system colors:
+ * - #36d1da (elite/very high)
+ * - #19abb5 (primary/high)
+ * - #f59e0b (warning/moderate-low)
+ * - #888888 (muted/very low)
+ */
+export function getConfidenceColor(confidence: number): string {
+  if (confidence >= CONFIDENCE_THRESHOLDS.veryHigh) return '#36d1da'
+  if (confidence >= CONFIDENCE_THRESHOLDS.moderate) return '#19abb5'
+  if (confidence >= CONFIDENCE_THRESHOLDS.low) return '#f59e0b'
+  return '#888888'
+}
+
+/**
+ * Get the label for a confidence level
+ */
+export function getConfidenceLabel(confidence: number): string {
+  if (confidence >= CONFIDENCE_THRESHOLDS.veryHigh) return 'Very High'
+  if (confidence >= CONFIDENCE_THRESHOLDS.high) return 'High'
+  if (confidence >= CONFIDENCE_THRESHOLDS.moderate) return 'Moderate'
+  if (confidence >= CONFIDENCE_THRESHOLDS.low) return 'Low'
+  return 'Very Low'
+}
+
+/**
+ * Get both color and label for a confidence level
+ */
+export function getConfidenceDisplay(confidence: number): {
+  color: string
+  label: string
+} {
+  return {
+    color: getConfidenceColor(confidence),
+    label: getConfidenceLabel(confidence),
+  }
+}
+
+/**
+ * Get a short label for compact displays
+ */
+export function getConfidenceLabelShort(confidence: number): string {
+  if (confidence >= CONFIDENCE_THRESHOLDS.veryHigh) return 'V.High'
+  if (confidence >= CONFIDENCE_THRESHOLDS.high) return 'High'
+  if (confidence >= CONFIDENCE_THRESHOLDS.moderate) return 'Med'
+  if (confidence >= CONFIDENCE_THRESHOLDS.low) return 'Low'
+  return 'V.Low'
+}
+
+/**
+ * Get the background color for confidence badges (with transparency)
+ */
+export function getConfidenceBgColor(confidence: number): string {
+  const baseColor = getConfidenceColor(confidence)
+  return `${baseColor}20` // 20% opacity
+}
+
+/**
+ * Get the border color for confidence badges
+ */
+export function getConfidenceBorderColor(confidence: number): string {
+  const baseColor = getConfidenceColor(confidence)
+  return `${baseColor}40` // 40% opacity
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -5748,3 +5748,498 @@ input:-webkit-autofill:focus {
   margin: 0;
   line-height: 1.5;
 }
+
+/* ============================================
+   Race Overview Component Styles
+   Overview-first navigation pattern
+   ============================================ */
+
+.race-overview {
+  width: 100%;
+  padding: var(--space-4);
+}
+
+.race-overview-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+@media (min-width: 640px) {
+  .race-overview-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.race-overview-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.race-overview-title h2 {
+  font-size: var(--font-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.race-overview-icon {
+  font-size: 24px;
+  color: var(--accent-primary);
+}
+
+.race-overview-stats {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.race-overview-stat {
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.race-overview-stat .tabular-nums {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.race-overview-stat-divider {
+  color: var(--text-tertiary);
+}
+
+.race-overview-stat-tier1 {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--accent-primary);
+}
+
+.race-overview-stat-tier1 .tabular-nums {
+  color: var(--accent-primary);
+}
+
+.race-overview-tier1-icon {
+  font-size: 16px;
+}
+
+.race-overview-hint {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-4);
+  font-size: var(--font-xs);
+  color: var(--text-tertiary);
+}
+
+.race-overview-hint-icon {
+  font-size: 14px;
+}
+
+/* Race Grid - Responsive layout */
+.race-overview-grid {
+  display: grid;
+  gap: var(--space-4);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .race-overview-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .race-overview-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Race Card */
+.race-card {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 0;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+  width: 100%;
+  overflow: hidden;
+}
+
+.race-card:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-prominent);
+  box-shadow: var(--shadow-md);
+}
+
+.race-card:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
+
+.race-card-has-tier1 {
+  border-color: rgba(25, 171, 181, 0.3);
+}
+
+.race-card-has-tier1:hover {
+  border-color: var(--accent-primary);
+}
+
+/* Race number badge */
+.race-card-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  min-width: 48px;
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-subtle);
+  font-size: var(--font-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+/* Main content area */
+.race-card-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+}
+
+.race-card-info {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.race-card-distance,
+.race-card-surface {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-sm);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.race-card-icon {
+  font-size: 16px;
+  color: var(--text-tertiary);
+}
+
+.race-card-details {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.race-card-class {
+  font-size: var(--font-xs);
+  font-weight: 600;
+  color: var(--accent-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.race-card-purse {
+  font-size: var(--font-xs);
+  color: var(--text-tertiary);
+}
+
+.race-card-horses {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.race-card-scratched {
+  color: var(--text-tertiary);
+}
+
+.race-card-horses-label {
+  color: var(--text-tertiary);
+}
+
+/* Top pick preview */
+.race-card-top-pick {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: var(--space-2) var(--space-3);
+  background: rgba(25, 171, 181, 0.08);
+  border-radius: var(--radius-sm);
+  margin-top: var(--space-1);
+}
+
+.race-card-star {
+  font-size: 14px;
+  color: var(--tier-gold);
+}
+
+.race-card-top-name {
+  font-size: var(--font-xs);
+  color: var(--text-primary);
+  font-weight: 500;
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.race-card-top-score {
+  font-size: var(--font-xs);
+  font-weight: 600;
+  color: var(--accent-primary);
+}
+
+/* Confidence badge */
+.race-card-confidence {
+  display: flex;
+  align-items: center;
+  padding-right: var(--space-3);
+}
+
+.confidence-badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid;
+  min-width: 64px;
+}
+
+.confidence-badge-small {
+  padding: var(--space-1) var(--space-2);
+  min-width: 48px;
+}
+
+.confidence-value {
+  font-size: var(--font-md);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.confidence-badge-small .confidence-value {
+  font-size: var(--font-sm);
+}
+
+.confidence-label {
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.9;
+}
+
+.confidence-badge-small .confidence-label {
+  font-size: 9px;
+}
+
+/* Tier 1 indicator */
+.race-card-tier1-indicator {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-primary);
+  color: white;
+  border-radius: 50%;
+}
+
+.race-card-tier1-indicator .material-icons {
+  font-size: 14px;
+}
+
+/* Chevron */
+.race-card-chevron {
+  position: absolute;
+  right: var(--space-2);
+  bottom: var(--space-2);
+  color: var(--text-tertiary);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.race-card:hover .race-card-chevron {
+  opacity: 1;
+}
+
+.race-card-chevron .material-icons {
+  font-size: 20px;
+}
+
+/* ============================================
+   Race Detail Header with Back Navigation
+   ============================================ */
+
+.race-detail-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--bg-card);
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: var(--space-4);
+}
+
+.race-detail-back-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: var(--font-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.race-detail-back-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-prominent);
+}
+
+.race-detail-back-btn .material-icons {
+  font-size: 18px;
+}
+
+.race-detail-back-hint {
+  font-size: var(--font-xs);
+  color: var(--text-tertiary);
+  margin-left: var(--space-2);
+}
+
+.race-detail-info {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.race-detail-title {
+  font-size: var(--font-xl);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.race-detail-subtitle {
+  font-size: var(--font-sm);
+  color: var(--text-secondary);
+}
+
+.race-detail-confidence {
+  margin-left: auto;
+}
+
+/* View transition animations */
+.view-enter {
+  opacity: 0;
+  transform: translateX(20px);
+}
+
+.view-enter-active {
+  opacity: 1;
+  transform: translateX(0);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.view-exit {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.view-exit-active {
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+/* ============================================
+   Dashboard View Containers
+   ============================================ */
+
+.dashboard-empty-container,
+.dashboard-overview-container {
+  width: 100%;
+}
+
+.dashboard-detail-container {
+  width: 100%;
+}
+
+.race-detail {
+  width: 100%;
+}
+
+.race-detail-content {
+  padding: 0 var(--space-4);
+}
+
+@media (min-width: 768px) {
+  .race-detail-content {
+    padding: 0 var(--space-6);
+  }
+}
+
+/* Race detail responsive adjustments */
+@media (max-width: 767px) {
+  .race-detail-header {
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    padding: var(--space-3);
+  }
+
+  .race-detail-back-hint {
+    display: none;
+  }
+
+  .race-detail-info {
+    order: 3;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-1);
+  }
+
+  .race-detail-confidence {
+    order: 2;
+    margin-left: auto;
+  }
+
+  .race-detail-title {
+    font-size: var(--font-lg);
+  }
+
+  .race-detail-subtitle {
+    font-size: var(--font-xs);
+  }
+}


### PR DESCRIPTION
This major refactor changes the app flow from race-by-race navigation to overview-first architecture where users see all races with confidence badges before drilling into individual race details.

Changes:
- Add RaceOverview component with confidence badges for all races
- Add RaceDetail component with back navigation and Escape key support
- Refactor Dashboard to manage 'overview' vs 'detail' view states
- Extract shared confidence utilities to src/lib/confidence.ts
- Remove duplicate confidence calculation from RaceTable
- Add responsive CSS for race cards and detail view
- Update MASTER_CONTEXT.md documentation with new architecture
- Add "Overview-first navigation" to Absolute Rules (#13)
- Update Phase 6 roadmap to reflect new UI patterns

User flow:
1. Upload DRF file -> See Race Overview with all races
2. Click race card -> Drill into Race Detail view
3. Press Back button or Escape -> Return to Overview

Performance optimizations:
- Race confidences calculated once on file load and cached
- Detail view scores recalculate only when user makes changes