### PR TITLE
Make DRF file extension validation case-insensitive

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -37,7 +37,14 @@ export function FileUpload({ onParsed }: FileUploadProps) {
   }
 
   const processFile = async (file: File) => {
-    if (!file.name.endsWith('.drf')) {
+    // Extract and normalize extension for case-insensitive comparison
+    const fileExtension = file.name.substring(file.name.lastIndexOf('.')).toLowerCase()
+    logger.logInfo('Processing file upload', {
+      originalFilename: file.name,
+      normalizedExtension: fileExtension,
+    })
+
+    if (fileExtension !== '.drf') {
       setParseStatus('error')
       setErrorMessage('Only .drf files are accepted')
       addToast(


### PR DESCRIPTION
Files from TwinSpires use uppercase .DRF extension which was being rejected. Now normalizes extension to lowercase before comparison and logs original filename with normalized extension for debugging.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
