### PR TITLE
Fix morning line odds column index to 43

### DIFF
--- a/src/lib/drfParser.ts
+++ b/src/lib/drfParser.ts
@@ -92,7 +92,7 @@ const DRF_COLUMNS = {
   // Weight and equipment (fields 50-70)
   WEIGHT: { index: 20, name: 'Weight' },
   APPRENTICE_ALLOWANCE: { index: 21, name: 'Apprentice Allowance' },
-  MORNING_LINE: { index: 22, name: 'Morning Line Odds' },
+  MORNING_LINE: { index: 43, name: 'Morning Line Odds' },
   EQUIPMENT: { index: 23, name: 'Equipment' },
   MEDICATION: { index: 24, name: 'Medication' },
 
@@ -1384,72 +1384,6 @@ export function parseDRFFile(
   // Split into lines
   const lines = content.split(/\r?\n/).filter((line) => line.trim().length > 0)
   const totalLines = lines.length
-
-  // =========================================================================
-  // DIAGNOSTIC LOGGING - TEMPORARY DEBUG CODE
-  // Purpose: Identify correct morning line odds column position
-  // =========================================================================
-  if (totalLines > 0) {
-    // Part 1: Log first raw CSV line (unsplit)
-    console.log('\n========== DRF DIAGNOSTIC: RAW DATA DUMP ==========')
-    console.log('First row (raw, unsplit):')
-    console.log(lines[0].substring(0, 500) + '...[truncated]')
-    console.log('')
-
-    // Parse first line to get column data
-    const firstLineFields = parseCSVLine(lines[0])
-
-    // Part 2: Log columns 20-50 for first horse
-    console.log('Columns 20-50 for first horse:')
-    for (let colIdx = 20; colIdx <= 50 && colIdx < firstLineFields.length; colIdx++) {
-      const value = firstLineFields[colIdx] || '[empty]'
-      console.log(`Col ${colIdx}: [${value}]`)
-    }
-    console.log('')
-
-    // Part 3: Log column 22 value for first 3 horses
-    console.log('Column 22 (current morning line index) for first 3 horses:')
-    for (let horseIdx = 0; horseIdx < Math.min(3, lines.length); horseIdx++) {
-      const horseFields = parseCSVLine(lines[horseIdx])
-      const horseName = horseFields[5] || 'Unknown'
-      const col22Value = horseFields[22] || '[empty]'
-      console.log(`Horse ${horseIdx + 1} (${horseName}): Col 22 = [${col22Value}]`)
-    }
-    console.log('')
-
-    // Part 4: Search columns 0-100 for odds-like patterns
-    // Odds patterns: "5-2", "3-1", "7/2", "10-1", "4-5", etc.
-    const oddsPattern = /^\d{1,3}[-\/]\d{1,2}$/
-    console.log('Searching columns 0-100 for odds-like values (X-X or X/X pattern):')
-    let foundOddsColumns: { col: number; value: string }[] = []
-
-    for (let colIdx = 0; colIdx < Math.min(100, firstLineFields.length); colIdx++) {
-      const value = (firstLineFields[colIdx] || '').trim()
-      if (value && oddsPattern.test(value)) {
-        foundOddsColumns.push({ col: colIdx, value })
-        console.log(`Possible odds found at column ${colIdx}: [${value}]`)
-      }
-    }
-
-    if (foundOddsColumns.length === 0) {
-      console.log('No odds-like values found in columns 0-100 with pattern X-X or X/X')
-
-      // Also check for decimal odds or whole numbers that could be odds
-      console.log('\nExpanded search for decimal/whole number odds patterns:')
-      const expandedPattern = /^(\d{1,2}(\.\d+)?|even|e)$/i
-      for (let colIdx = 0; colIdx < Math.min(100, firstLineFields.length); colIdx++) {
-        const value = (firstLineFields[colIdx] || '').trim()
-        if (value && expandedPattern.test(value) && parseFloat(value) > 0 && parseFloat(value) < 100) {
-          console.log(`Possible decimal/whole odds at column ${colIdx}: [${value}]`)
-        }
-      }
-    }
-
-    console.log('\n========== END DRF DIAGNOSTIC ==========\n')
-  }
-  // =========================================================================
-  // END DIAGNOSTIC LOGGING
-  // =========================================================================
 
   if (totalLines === 0) {
     const emptyError = new DRFParseError('EMPTY_FILE', 'No data lines found in file', {


### PR DESCRIPTION
- Column 22 contains breed code ("TB"), not odds
- Column 43 contains decimal format odds (5.00 = 5-1)
- Removed diagnostic logging added in previous commit
- parseOdds() already handles decimal format correctly

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
