### PR TITLE
Fix dashboard panel layout in detail mode

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,14 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Sidebar, TopBar, MobileNav, Footer, RaceTabsBar, BettingDrawer, StatusBar } from './layout';
+import {
+  Sidebar,
+  TopBar,
+  MobileNav,
+  Footer,
+  RaceTabsBar,
+  BettingDrawer,
+  StatusBar,
+} from './layout';
 import type { LegalContentType } from './legal';
 import { EmptyStateTable } from './cards';
 import { FileUpload } from './FileUpload';
@@ -80,11 +88,11 @@ export function Dashboard({
 
   const hasData = !!parsedData && parsedData.races.length > 0;
 
-  // Reset to overview when new file is loaded
+  // Go to detail view when new file is loaded (panel layout is the main UI)
   useEffect(() => {
     if (parsedData) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- Syncing external state when new data is loaded
-      setCurrentView('overview');
+      setCurrentView('detail');
       setSelectedRaceIndex(0);
     }
   }, [parsedData]);
@@ -572,11 +580,7 @@ export function Dashboard({
                 </div>
 
                 {/* Status Bar */}
-                <StatusBar
-                  trackDbLoaded={true}
-                  isCalculating={false}
-                  isOffline={false}
-                />
+                <StatusBar trackDbLoaded={true} isCalculating={false} isOffline={false} />
               </motion.div>
             ) : null}
           </AnimatePresence>


### PR DESCRIPTION
Changed default view from 'overview' (race card grid) to 'detail' (panel layout with race tabs, horse table, and betting drawer) so the panel architecture is the main landing page.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
