### PR TITLE
Build Statistics Table for racing records

### DIFF
--- a/src/components/HorseExpandedView.css
+++ b/src/components/HorseExpandedView.css
@@ -213,3 +213,96 @@
   background: var(--color-primary-muted);
   color: var(--color-primary);
 }
+
+/* ============================================
+   STATISTICS TABLE (Compact Single Row)
+   ============================================ */
+
+.horse-expanded-view__section--stats {
+  padding: 6px 16px;
+  background: var(--color-base);
+}
+
+.horse-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.2;
+}
+
+.horse-stats__group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.horse-stats__group--primary {
+  /* Primary records slightly emphasized */
+}
+
+.horse-stats__group--splits {
+  /* Splits are secondary info */
+}
+
+.horse-stats__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.horse-stats__item--split {
+  /* Splits are slightly smaller */
+}
+
+.horse-stats__label {
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.horse-stats__record {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.horse-stats__item--split .horse-stats__record {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.horse-stats__earnings {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-tier-good);
+  margin-left: 2px;
+}
+
+.horse-stats__divider {
+  color: var(--color-border);
+  font-size: 11px;
+  font-weight: 300;
+  margin: 0 1px;
+  user-select: none;
+}
+
+.horse-stats__divider--section {
+  color: var(--color-text-tertiary);
+  font-weight: 400;
+  margin: 0 4px;
+}
+
+/* Hide placeholder */
+.horse-expanded-view__section--stats .horse-expanded-view__section-placeholder {
+  display: none;
+}
+
+/* Good win rate highlight */
+.horse-stats__record--hot {
+  color: var(--color-tier-good);
+}

--- a/src/components/HorseExpandedView.tsx
+++ b/src/components/HorseExpandedView.tsx
@@ -17,6 +17,24 @@ const getTierClass = (value: number): string => {
   return 'bad';
 };
 
+// Format earnings with K/M abbreviations
+const formatEarnings = (amount: number): string => {
+  if (!amount || amount === 0) return '0';
+  if (amount >= 1000000) {
+    return (amount / 1000000).toFixed(1) + 'M';
+  }
+  if (amount >= 1000) {
+    return (amount / 1000).toFixed(0) + 'K';
+  }
+  return amount.toLocaleString();
+};
+
+// Helper to determine if win rate is good (25%+)
+const isGoodWinRate = (starts: number, wins: number): boolean => {
+  if (!starts || starts < 2) return false;
+  return wins / starts >= 0.25;
+};
+
 export const HorseExpandedView: React.FC<HorseExpandedViewProps> = ({
   horse,
   isVisible,
@@ -159,12 +177,118 @@ export const HorseExpandedView: React.FC<HorseExpandedViewProps> = ({
 
       {/* Section 3: Statistics Table */}
       <section className="horse-expanded-view__section horse-expanded-view__section--stats">
-        <div className="horse-expanded-view__section-placeholder">
-          STATISTICS TABLE
-          <span className="horse-expanded-view__placeholder-note">
-            (Lifetime, Current Year, Previous Year, Surface Splits)
-          </span>
-          <span className="horse-expanded-view__placeholder-note">(Prompt 3)</span>
+        <div className="horse-stats">
+          {/* Primary Records */}
+          <div className="horse-stats__group horse-stats__group--primary">
+            {/* Lifetime */}
+            <div className="horse-stats__item">
+              <span className="horse-stats__label">LIFE:</span>
+              <span className="horse-stats__record">
+                {horse.lifetimeStarts || 0}-{horse.lifetimeWins || 0}-{horse.lifetimePlaces || 0}-
+                {horse.lifetimeShows || 0}
+              </span>
+              {(horse.lifetimeEarnings || 0) > 0 && (
+                <span className="horse-stats__earnings">
+                  ${formatEarnings(horse.lifetimeEarnings)}
+                </span>
+              )}
+            </div>
+
+            <span className="horse-stats__divider">|</span>
+
+            {/* Current Year */}
+            <div className="horse-stats__item">
+              <span className="horse-stats__label">{new Date().getFullYear()}:</span>
+              <span className="horse-stats__record">
+                {horse.currentYearStarts || 0}-{horse.currentYearWins || 0}-
+                {horse.currentYearPlaces || 0}-{horse.currentYearShows || 0}
+              </span>
+              {(horse.currentYearEarnings || 0) > 0 && (
+                <span className="horse-stats__earnings">
+                  ${formatEarnings(horse.currentYearEarnings)}
+                </span>
+              )}
+            </div>
+
+            <span className="horse-stats__divider">|</span>
+
+            {/* Previous Year */}
+            <div className="horse-stats__item">
+              <span className="horse-stats__label">{new Date().getFullYear() - 1}:</span>
+              <span className="horse-stats__record">
+                {horse.previousYearStarts || 0}-{horse.previousYearWins || 0}-
+                {horse.previousYearPlaces || 0}-{horse.previousYearShows || 0}
+              </span>
+              {(horse.previousYearEarnings || 0) > 0 && (
+                <span className="horse-stats__earnings">
+                  ${formatEarnings(horse.previousYearEarnings)}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Surface/Distance Splits */}
+          <div className="horse-stats__group horse-stats__group--splits">
+            <span className="horse-stats__divider horse-stats__divider--section">│</span>
+
+            {/* Dirt Fast */}
+            <div className="horse-stats__item horse-stats__item--split">
+              <span className="horse-stats__label">D.Fst:</span>
+              <span
+                className={`horse-stats__record ${isGoodWinRate(horse.surfaceStarts || 0, horse.surfaceWins || 0) ? 'horse-stats__record--hot' : ''}`}
+              >
+                {horse.surfaceStarts || 0}-{horse.surfaceWins || 0}
+              </span>
+            </div>
+
+            <span className="horse-stats__divider">|</span>
+
+            {/* Wet */}
+            <div className="horse-stats__item horse-stats__item--split">
+              <span className="horse-stats__label">Wet:</span>
+              <span
+                className={`horse-stats__record ${isGoodWinRate(horse.wetStarts || 0, horse.wetWins || 0) ? 'horse-stats__record--hot' : ''}`}
+              >
+                {horse.wetStarts || 0}-{horse.wetWins || 0}
+              </span>
+            </div>
+
+            <span className="horse-stats__divider">|</span>
+
+            {/* Turf */}
+            <div className="horse-stats__item horse-stats__item--split">
+              <span className="horse-stats__label">Turf:</span>
+              <span
+                className={`horse-stats__record ${isGoodWinRate(horse.turfStarts || 0, horse.turfWins || 0) ? 'horse-stats__record--hot' : ''}`}
+              >
+                {horse.turfStarts || 0}-{horse.turfWins || 0}
+              </span>
+            </div>
+
+            <span className="horse-stats__divider">|</span>
+
+            {/* Distance */}
+            <div className="horse-stats__item horse-stats__item--split">
+              <span className="horse-stats__label">Dist:</span>
+              <span
+                className={`horse-stats__record ${isGoodWinRate(horse.distanceStarts || 0, horse.distanceWins || 0) ? 'horse-stats__record--hot' : ''}`}
+              >
+                {horse.distanceStarts || 0}-{horse.distanceWins || 0}
+              </span>
+            </div>
+
+            <span className="horse-stats__divider">|</span>
+
+            {/* Track */}
+            <div className="horse-stats__item horse-stats__item--split">
+              <span className="horse-stats__label">Trk:</span>
+              <span
+                className={`horse-stats__record ${isGoodWinRate(horse.trackStarts || 0, horse.trackWins || 0) ? 'horse-stats__record--hot' : ''}`}
+              >
+                {horse.trackStarts || 0}-{horse.trackWins || 0}
+              </span>
+            </div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
Add DRF-style statistics display showing:
- Lifetime record (starts-wins-places-shows) with earnings
- Current and previous year records with earnings
- Surface/distance splits (D.Fst, Wet, Turf, Dist, Trk)
- Win rate highlighting for splits ≥25%
- Compact single-row layout that wraps gracefully

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
