### PR TITLE
Build past performance line component

### DIFF
--- a/src/components/HorseExpandedView.tsx
+++ b/src/components/HorseExpandedView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './HorseExpandedView.css';
-import type { HorseEntry } from '../types/drf';
+import { PPLine } from './PPLine';
+import type { HorseEntry, PastPerformance } from '../types/drf';
 import type { HorseScore } from '../lib/scoring';
 
 interface HorseExpandedViewProps {
@@ -474,12 +475,14 @@ export const HorseExpandedView: React.FC<HorseExpandedViewProps> = ({
             <span className="horse-pp__col horse-pp__col--comment">COMMENT</span>
           </div>
 
-          {/* PP Lines will go here - Placeholder for now */}
+          {/* PP Lines */}
           <div className="horse-pp__lines">
             {horse.pastPerformances && horse.pastPerformances.length > 0 ? (
-              <div className="horse-pp__placeholder-text">
-                {horse.pastPerformances.length} past performances — (Prompt 6-7)
-              </div>
+              horse.pastPerformances
+                .slice(0, 10)
+                .map((pp: PastPerformance, index: number) => (
+                  <PPLine key={`${pp.date}-${pp.track}-${index}`} pp={pp} index={index} />
+                ))
             ) : (
               <div className="horse-pp__no-data">
                 No past performances available (First-time starter)

--- a/src/components/PPLine.css
+++ b/src/components/PPLine.css
@@ -1,0 +1,135 @@
+/* ============================================
+   PAST PERFORMANCE LINE (Single Race)
+   ============================================ */
+
+.pp-line {
+  display: flex;
+  align-items: center;
+  padding: 2px 8px;
+  gap: 0;
+  font-family: 'SF Mono', 'Monaco', 'Consolas', 'Courier New', monospace;
+  font-size: 11px;
+  line-height: 1.3;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.pp-line:last-child {
+  border-bottom: none;
+}
+
+/* Alternating row colors */
+.pp-line--even {
+  background: #f8f8f8;
+}
+
+.pp-line--odd {
+  background: #ffffff;
+}
+
+.pp-line:hover {
+  background: #e8f4f8;
+}
+
+/* ============================================
+   PP LINE COLUMNS
+   ============================================ */
+
+.pp-line__col {
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #1a1a1a;
+}
+
+/* Match header column widths exactly */
+.pp-line__col--date {
+  width: 70px;
+  min-width: 70px;
+  font-weight: 600;
+}
+
+.pp-line__col--track {
+  width: 36px;
+  min-width: 36px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.pp-line__col--dist {
+  width: 50px;
+  min-width: 50px;
+  text-align: center;
+}
+
+.pp-line__col--cond {
+  width: 36px;
+  min-width: 36px;
+  text-align: center;
+  font-size: 10px;
+}
+
+.pp-line__col--class {
+  width: 80px;
+  min-width: 80px;
+  font-size: 10px;
+}
+
+.pp-line__col--finish {
+  width: 40px;
+  min-width: 40px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.pp-line__col--finish.pp-line__col--win {
+  color: #16a34a;
+  font-weight: 700;
+}
+
+.pp-line__col--odds {
+  width: 44px;
+  min-width: 44px;
+  text-align: right;
+}
+
+.pp-line__col--odds.pp-line__col--fav {
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.pp-line__col--figure {
+  width: 32px;
+  min-width: 32px;
+  text-align: center;
+  font-weight: 700;
+  color: #2563eb;
+}
+
+.pp-line__col--running {
+  width: 140px;
+  min-width: 140px;
+  font-size: 10px;
+  letter-spacing: -0.02em;
+}
+
+.pp-line__col--jockey {
+  width: 90px;
+  min-width: 90px;
+  font-size: 10px;
+}
+
+.pp-line__col--weight {
+  width: 32px;
+  min-width: 32px;
+  text-align: center;
+  font-size: 10px;
+}
+
+.pp-line__col--comment {
+  flex: 1;
+  min-width: 100px;
+  font-size: 10px;
+  font-style: italic;
+  color: #666;
+}

--- a/src/components/PPLine.tsx
+++ b/src/components/PPLine.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import './PPLine.css';
+import type { PastPerformance, RunningLine } from '../types/drf';
+
+interface PPLineProps {
+  pp: PastPerformance;
+  index: number; // For alternating row colors
+}
+
+export const PPLine: React.FC<PPLineProps> = ({ pp, index }) => {
+  // Format date: "01/25/24" or "Jan 25"
+  const formatDate = (dateStr: string): string => {
+    if (!dateStr) return '—';
+    try {
+      const date = new Date(dateStr);
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const day = String(date.getDate()).padStart(2, '0');
+      const year = String(date.getFullYear()).slice(-2);
+      return `${month}/${day}/${year}`;
+    } catch {
+      return dateStr.slice(0, 8) || '—';
+    }
+  };
+
+  // Format distance: "6f", "8.5f", "1m", "1 1/16m"
+  const formatDistance = (furlongs: number, distStr?: string): string => {
+    if (distStr) {
+      // Abbreviate common formats
+      return distStr
+        .replace('furlongs', 'f')
+        .replace('furlong', 'f')
+        .replace('miles', 'm')
+        .replace('mile', 'm')
+        .replace(' ', '')
+        .slice(0, 6);
+    }
+    if (!furlongs) return '—';
+    if (furlongs >= 8) {
+      const miles = furlongs / 8;
+      return miles % 1 === 0 ? `${miles}m` : `${miles.toFixed(2)}m`;
+    }
+    return `${furlongs}f`;
+  };
+
+  // Format track condition: "fst", "gd", "sly", "my"
+  const formatCondition = (condition: string): string => {
+    if (!condition) return '—';
+    const abbrevs: Record<string, string> = {
+      fast: 'fst',
+      good: 'gd',
+      sloppy: 'sly',
+      muddy: 'my',
+      firm: 'fm',
+      yielding: 'yl',
+      soft: 'sf',
+      'wet fast': 'wf',
+      slow: 'sl',
+    };
+    return abbrevs[condition.toLowerCase()] || condition.slice(0, 3).toLowerCase();
+  };
+
+  // Format class: "ALW65K", "MSW", "CLM25K", "G1"
+  const formatClass = (ppData: PastPerformance): string => {
+    const classification = ppData.classification || '';
+    const purse = ppData.purse || 0;
+    const claiming = ppData.claimingPrice;
+
+    // Grade stakes
+    if (classification.toLowerCase().includes('grade') || classification.match(/g[1-3]/i)) {
+      return classification.toUpperCase().slice(0, 6);
+    }
+
+    // Claiming
+    if (claiming) {
+      return `CLM${Math.round(claiming / 1000)}K`;
+    }
+
+    // Allowance
+    if (
+      classification.toLowerCase().includes('allowance') ||
+      classification.toLowerCase() === 'alw'
+    ) {
+      const purseK = purse >= 1000 ? Math.round(purse / 1000) + 'K' : purse;
+      return `ALW${purseK}`;
+    }
+
+    // Maiden Special Weight
+    if (classification.toLowerCase().includes('maiden special')) {
+      return 'MSW';
+    }
+
+    // Maiden Claiming
+    if (classification.toLowerCase().includes('maiden claim')) {
+      return `MCL${claiming ? Math.round(claiming / 1000) + 'K' : ''}`;
+    }
+
+    // Stakes
+    if (classification.toLowerCase().includes('stakes')) {
+      return 'STK';
+    }
+
+    // Fallback
+    return classification.slice(0, 7).toUpperCase() || '—';
+  };
+
+  // Format finish: "2/10" (position/field)
+  const formatFinish = (position: number, fieldSize: number): string => {
+    if (!position) return '—';
+    return `${position}/${fieldSize || '?'}`;
+  };
+
+  // Format odds: "4.5", "12", "*1.2" (favorite)
+  const formatOdds = (odds: number | null, favRank?: number | null): string => {
+    if (odds === null || odds === undefined) return '—';
+    const prefix = favRank === 1 ? '*' : '';
+    return prefix + (odds < 10 ? odds.toFixed(1) : Math.round(odds).toString());
+  };
+
+  // Format lengths as superscript-style: "½", "1½", "2", "hd", "nk", "ns"
+  const formatLengths = (lengths: string | number): string => {
+    if (!lengths) return '';
+    const l = String(lengths).toLowerCase();
+    if (l === 'head' || l === 'hd') return 'ʰᵈ';
+    if (l === 'neck' || l === 'nk') return 'ⁿᵏ';
+    if (l === 'nose' || l === 'ns') return 'ⁿˢ';
+    // Numeric lengths - use superscript style
+    return `${l}`.replace('.5', '½').replace('1/2', '½');
+  };
+
+  // Format running line: "3² 2¹ 2½ 2¹ 2¹½"
+  const formatRunningLine = (rl: RunningLine | null | undefined): string => {
+    if (!rl) return '—';
+
+    const positions = [
+      rl.start,
+      rl.quarterMile,
+      rl.halfMile,
+      rl.threeQuarters,
+      rl.stretch,
+      rl.finish,
+    ].filter((p) => p !== null && p !== undefined);
+
+    if (positions.length === 0) return '—';
+
+    // For now, just show positions. Lengths can be added with superscript later.
+    // Note: start position has no lengths value
+    const lengthsArray = [
+      null, // start has no lengths
+      rl.quarterMileLengths,
+      rl.halfMileLengths,
+      rl.threeQuartersLengths,
+      rl.stretchLengths,
+      rl.finishLengths,
+    ];
+
+    return positions
+      .map((pos, i) => {
+        const lengths = lengthsArray[i];
+
+        if (lengths !== null && lengths !== undefined) {
+          return `${pos}${formatLengths(lengths)}`;
+        }
+        return String(pos);
+      })
+      .join(' ');
+  };
+
+  // Format jockey name: "Rosario J" or "Prat F"
+  const formatJockey = (name: string): string => {
+    if (!name) return '—';
+    const parts = name.trim().split(' ').filter(Boolean);
+    if (parts.length === 0) return '—';
+    if (parts.length === 1) return (parts[0] || '').slice(0, 10);
+    // Last name + first initial
+    const lastName = parts[parts.length - 1] || '';
+    const firstInitial = (parts[0] || '').charAt(0);
+    return `${lastName} ${firstInitial}`.slice(0, 12);
+  };
+
+  // Format comment: truncate if too long
+  const formatComment = (tripComment?: string, comment?: string): string => {
+    const text = tripComment || comment || '';
+    return text.slice(0, 30) || '—';
+  };
+
+  const isEven = index % 2 === 0;
+
+  return (
+    <div className={`pp-line ${isEven ? 'pp-line--even' : 'pp-line--odd'}`}>
+      <span className="pp-line__col pp-line__col--date">{formatDate(pp.date)}</span>
+      <span className="pp-line__col pp-line__col--track">{pp.track || '—'}</span>
+      <span className="pp-line__col pp-line__col--dist">
+        {formatDistance(pp.distanceFurlongs, pp.distance)}
+      </span>
+      <span className="pp-line__col pp-line__col--cond">{formatCondition(pp.trackCondition)}</span>
+      <span className="pp-line__col pp-line__col--class">{formatClass(pp)}</span>
+      <span
+        className={`pp-line__col pp-line__col--finish ${pp.finishPosition === 1 ? 'pp-line__col--win' : ''}`}
+      >
+        {formatFinish(pp.finishPosition, pp.fieldSize)}
+      </span>
+      <span
+        className={`pp-line__col pp-line__col--odds ${pp.favoriteRank === 1 ? 'pp-line__col--fav' : ''}`}
+      >
+        {formatOdds(pp.odds, pp.favoriteRank)}
+      </span>
+      <span className="pp-line__col pp-line__col--figure">{pp.speedFigures?.beyer ?? '—'}</span>
+      <span className="pp-line__col pp-line__col--running">
+        {formatRunningLine(pp.runningLine)}
+      </span>
+      <span className="pp-line__col pp-line__col--jockey">{formatJockey(pp.jockey)}</span>
+      <span className="pp-line__col pp-line__col--weight">{pp.weight || '—'}</span>
+      <span
+        className="pp-line__col pp-line__col--comment"
+        title={pp.tripComment || pp.comment || ''}
+      >
+        {formatComment(pp.tripComment, pp.comment)}
+      </span>
+    </div>
+  );
+};
+
+export default PPLine;


### PR DESCRIPTION
Create PPLine component to display individual race history lines in DRF-style format. Each line shows date, track, distance, condition, class, finish position, odds, speed figure, running line, jockey, weight, and comment in a compact 20-24px row.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
