### PR TITLE
Fix data parsing issues in expanded view

### DIFF
--- a/src/components/PPLine.css
+++ b/src/components/PPLine.css
@@ -128,8 +128,22 @@
 
 .pp-line__col--comment {
   flex: 1;
-  min-width: 100px;
-  font-size: 9px; /* Reduced from 10px */
+  min-width: 150px; /* Increased from 100px */
+  max-width: 250px; /* Add max to prevent too wide */
+  font-size: 9px;
   font-style: italic;
   color: #666;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* On hover, show full comment */
+.pp-line:hover .pp-line__col--comment {
+  white-space: normal;
+  overflow: visible;
+  position: relative;
+  z-index: 5;
+  background: #fff;
+  padding-right: 8px;
 }


### PR DESCRIPTION
…mments

- Fix date parsing to handle YYYYMMDD, ISO, and pre-formatted date strings
- Add safe track display formatter to handle NaN and undefined values
- Improve running line formatting with proper position and lengths handling
- Fix workout formatters for dates, tracks, distances, times, and rankings
- Add validation to skip invalid workout items
- Increase comment column width and truncation length (30 -> 50 chars)
- Add hover effect to show full comment text
- Add debug logging for workout and PP data structures

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
