### PR TITLE
Fix distance formatting for racing fractions

### DIFF
--- a/src/components/HorseExpandedView.tsx
+++ b/src/components/HorseExpandedView.tsx
@@ -3,6 +3,7 @@ import './HorseExpandedView.css';
 import { PPLine } from './PPLine';
 import type { HorseEntry, PastPerformance, Workout } from '../types/drf';
 import type { HorseScore } from '../lib/scoring';
+import { formatRacingDistance } from '../utils/formatters';
 
 // Determine tier class based on value percentage
 const getTierClass = (value: number): string => {
@@ -129,7 +130,8 @@ const WorkoutItem: React.FC<WorkoutItemProps> = ({ workout }) => {
     return str.toUpperCase().slice(0, 3);
   };
 
-  // Get workout distance - distanceFurlongs should already be calculated by parser (yards / 220)
+  // Get workout distance using centralized formatter
+  // distanceFurlongs is calculated by parser (yards / 220)
   const getWorkoutDistance = (): string => {
     const furlongs = w.distanceFurlongs;
 
@@ -145,17 +147,8 @@ const WorkoutItem: React.FC<WorkoutItemProps> = ({ workout }) => {
       return '—';
     }
 
-    // Format nicely
-    if (furlongs === 8) return '1m';
-    if (furlongs % 1 === 0) return `${furlongs}f`;
-    if (furlongs === 5.5) return '5½f';
-    if (furlongs === 6.5) return '6½f';
-    if (furlongs === 7.5) return '7½f';
-
-    // For odd values, round to nearest half
-    const rounded = Math.round(furlongs * 2) / 2;
-    if (rounded % 1 === 0) return `${rounded}f`;
-    return `${Math.floor(rounded)}½f`;
+    // Use the standard racing distance formatter
+    return formatRacingDistance(furlongs);
   };
 
   // Format surface/condition safely

--- a/src/components/PPLine.tsx
+++ b/src/components/PPLine.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './PPLine.css';
 import type { PastPerformance, RunningLine } from '../types/drf';
+import { formatRacingDistance } from '../utils/formatters';
 
 interface PPLineProps {
   pp: PastPerformance;
@@ -57,77 +58,7 @@ export const PPLine: React.FC<PPLineProps> = ({ pp, index }) => {
     return str.toUpperCase().slice(0, 3);
   };
 
-  // Format distance: "6f", "6½f", "1m", "1⅛m" with proper unicode fractions
-  const formatDistance = (furlongs: number, distStr?: string): string => {
-    // If we have a string, clean it up with unicode fractions
-    if (distStr && typeof distStr === 'string') {
-      let cleaned = distStr.trim();
-
-      // Replace common fraction patterns with unicode fractions
-      cleaned = cleaned
-        .replace('1/2', '½')
-        .replace('1/4', '¼')
-        .replace('3/4', '¾')
-        .replace('1/8', '⅛')
-        .replace('3/8', '⅜')
-        .replace('5/8', '⅝')
-        .replace('7/8', '⅞')
-        .replace('1/16', '¹⁄₁₆')
-        .replace(' furlongs', 'f')
-        .replace(' furlong', 'f')
-        .replace('furlongs', 'f')
-        .replace('furlong', 'f')
-        .replace(' miles', 'm')
-        .replace(' mile', 'm')
-        .replace('miles', 'm')
-        .replace('mile', 'm')
-        .replace(' m', 'm')
-        .replace(' f', 'f');
-
-      // Remove extra spaces
-      cleaned = cleaned.replace(/\s+/g, '');
-
-      return cleaned.slice(0, 8);
-    }
-
-    // Convert furlongs number to string with unicode fractions
-    if (!furlongs || isNaN(furlongs)) return '—';
-
-    // Common furlong values to miles with fractions
-    if (furlongs === 6.125) return '6⅛m';
-    if (furlongs === 6.25) return '6¼m';
-    if (furlongs === 6.5) return '6½f';
-    if (furlongs === 8) return '1m';
-    if (furlongs === 8.5) return '1¹⁄₁₆m';
-    if (furlongs === 9) return '1⅛m';
-    if (furlongs === 10) return '1¼m';
-    if (furlongs === 11) return '1⅜m';
-    if (furlongs === 12) return '1½m';
-    if (furlongs === 13) return '1⅝m';
-    if (furlongs === 14) return '1¾m';
-
-    // Under 8 furlongs - show as furlongs
-    if (furlongs < 8) {
-      if (furlongs % 1 === 0) return `${furlongs}f`;
-      if (furlongs % 1 === 0.5) return `${Math.floor(furlongs)}½f`;
-      if (furlongs % 1 === 0.25) return `${Math.floor(furlongs)}¼f`;
-      if (furlongs % 1 === 0.75) return `${Math.floor(furlongs)}¾f`;
-      return `${furlongs.toFixed(1)}f`;
-    }
-
-    // 8+ furlongs - show as miles
-    const miles = furlongs / 8;
-    if (miles % 1 === 0) return `${miles}m`;
-    if (miles % 1 === 0.125) return `${Math.floor(miles)}⅛m`;
-    if (miles % 1 === 0.25) return `${Math.floor(miles)}¼m`;
-    if (miles % 1 === 0.375) return `${Math.floor(miles)}⅜m`;
-    if (miles % 1 === 0.5) return `${Math.floor(miles)}½m`;
-    if (miles % 1 === 0.625) return `${Math.floor(miles)}⅝m`;
-    if (miles % 1 === 0.75) return `${Math.floor(miles)}¾m`;
-    if (miles % 1 === 0.875) return `${Math.floor(miles)}⅞m`;
-
-    return `${miles.toFixed(2)}m`;
-  };
+  // Distance formatting now uses centralized formatRacingDistance from utils/formatters
 
   // Format track condition: "fst", "gd", "sly", "my"
   const formatCondition = (condition: string): string => {
@@ -358,7 +289,7 @@ export const PPLine: React.FC<PPLineProps> = ({ pp, index }) => {
       <span className="pp-line__col pp-line__col--date">{formatDate(pp.date)}</span>
       <span className="pp-line__col pp-line__col--track">{formatTrack(pp.track)}</span>
       <span className="pp-line__col pp-line__col--dist">
-        {formatDistance(pp.distanceFurlongs, pp.distance)}
+        {formatRacingDistance(pp.distanceFurlongs)}
       </span>
       <span className="pp-line__col pp-line__col--cond">{formatCondition(pp.trackCondition)}</span>
       <span className="pp-line__col pp-line__col--class">{formatClass(pp)}</span>

--- a/src/lib/drfParser.ts
+++ b/src/lib/drfParser.ts
@@ -1217,6 +1217,8 @@ function parseWorkouts(fields: string[], maxWorkouts = 10): Workout[] {
 
     // Parse distance (convert from yards to furlongs: 220 yards per furlong)
     // DRF stores workout distances in yards (e.g., 1320y = 6f, 1760y = 1 mile)
+    // Common workout distances:
+    //   880y = 4f, 1100y = 5f, 1320y = 6f, 1540y = 7f, 1760y = 8f/1m
     const distanceYards = parseFloatSafe(getField(fields, WK_DISTANCE_YARDS + i));
     const distanceFurlongs = distanceYards > 0 ? distanceYards / 220 : 0;
     // Format as standard workout distances

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,177 @@
+/**
+ * Racing distance and number formatting utilities
+ *
+ * Provides standardized formatting for racing distances matching
+ * Equibase/DRF industry conventions.
+ */
+
+/**
+ * Convert furlongs to standard racing distance format
+ *
+ * Racing industry standard:
+ * - Under 8 furlongs: show as furlongs (6f, 6½f)
+ * - 8 furlongs = 1 mile: show as "1m"
+ * - Over 1 mile: show as miles with fractions (1⅛m, 1¼m)
+ *
+ * Common distances:
+ * - Sprint: 4f, 4½f, 5f, 5½f, 6f, 6½f, 7f
+ * - Route: 1m, 1¹⁄₁₆m, 1⅛m, 1³⁄₁₆m, 1¼m, 1³⁄₈m, 1½m, 1⅝m, 1¾m, 2m
+ *
+ * @param furlongs - Distance in furlongs (1 mile = 8 furlongs)
+ * @returns Formatted distance string (e.g., "6f", "1⅛m")
+ */
+export const formatRacingDistance = (furlongs: number): string => {
+  if (!furlongs || isNaN(furlongs) || furlongs <= 0) return '—';
+
+  // Standard race distances in furlongs and their display format
+  // Using proper Unicode fractions for professional display
+  const standardDistances: Record<number, string> = {
+    // Sprint distances (furlongs)
+    2: '2f',
+    2.5: '2½f',
+    3: '3f',
+    3.5: '3½f',
+    4: '4f',
+    4.5: '4½f',
+    5: '5f',
+    5.5: '5½f',
+    6: '6f',
+    6.5: '6½f',
+    7: '7f',
+    7.5: '7½f',
+    // Route distances (miles) - 8 furlongs = 1 mile
+    8: '1m',
+    8.5: '1¹⁄₁₆m', // 1 and 1/16 mile (8.5 furlongs)
+    9: '1⅛m', // 1 and 1/8 mile (9 furlongs)
+    9.5: '1³⁄₁₆m', // 1 and 3/16 mile (9.5 furlongs)
+    10: '1¼m', // 1 and 1/4 mile (10 furlongs)
+    10.5: '1⁵⁄₁₆m', // 1 and 5/16 mile (10.5 furlongs)
+    11: '1³⁄₈m', // 1 and 3/8 mile (11 furlongs)
+    12: '1½m', // 1 and 1/2 mile (12 furlongs)
+    13: '1⅝m', // 1 and 5/8 mile (13 furlongs)
+    14: '1¾m', // 1 and 3/4 mile (14 furlongs)
+    16: '2m', // 2 miles (16 furlongs)
+    18: '2¼m', // 2 and 1/4 miles (18 furlongs)
+    20: '2½m', // 2 and 1/2 miles (20 furlongs)
+  };
+
+  // Round to nearest standard distance (within 0.15 tolerance for parsing variance)
+  for (const [standard, display] of Object.entries(standardDistances)) {
+    if (Math.abs(furlongs - Number(standard)) < 0.15) {
+      return display;
+    }
+  }
+
+  // If not a standard distance, format manually
+  if (furlongs < 8) {
+    // Show as furlongs for sprint distances
+    const whole = Math.floor(furlongs);
+    const frac = furlongs - whole;
+
+    if (frac < 0.1) return `${whole}f`;
+    if (Math.abs(frac - 0.5) < 0.1) return `${whole}½f`;
+    if (Math.abs(frac - 0.25) < 0.1) return `${whole}¼f`;
+    if (Math.abs(frac - 0.75) < 0.1) return `${whole}¾f`;
+
+    // For unusual fractions, show decimal
+    return `${furlongs.toFixed(1)}f`;
+  } else {
+    // Show as miles for route distances (8+ furlongs)
+    const miles = furlongs / 8;
+    const whole = Math.floor(miles);
+    const frac = miles - whole;
+
+    if (frac < 0.05) return `${whole}m`;
+    if (Math.abs(frac - 0.0625) < 0.02) return `${whole}¹⁄₁₆m`; // 1/16
+    if (Math.abs(frac - 0.125) < 0.02) return `${whole}⅛m`; // 1/8
+    if (Math.abs(frac - 0.1875) < 0.02) return `${whole}³⁄₁₆m`; // 3/16
+    if (Math.abs(frac - 0.25) < 0.02) return `${whole}¼m`; // 1/4
+    if (Math.abs(frac - 0.3125) < 0.02) return `${whole}⁵⁄₁₆m`; // 5/16
+    if (Math.abs(frac - 0.375) < 0.02) return `${whole}³⁄₈m`; // 3/8
+    if (Math.abs(frac - 0.5) < 0.02) return `${whole}½m`; // 1/2
+    if (Math.abs(frac - 0.625) < 0.02) return `${whole}⅝m`; // 5/8
+    if (Math.abs(frac - 0.75) < 0.02) return `${whole}¾m`; // 3/4
+    if (Math.abs(frac - 0.875) < 0.02) return `${whole}⅞m`; // 7/8
+
+    // For unusual fractions, show decimal miles
+    return `${miles.toFixed(2)}m`;
+  }
+};
+
+/**
+ * Format earnings with K/M abbreviations
+ *
+ * @param amount - Earnings amount in dollars
+ * @returns Formatted string (e.g., "$125K", "$1.2M")
+ */
+export const formatEarnings = (amount: number): string => {
+  if (!amount || amount === 0) return '$0';
+  if (amount >= 1000000) {
+    return '$' + (amount / 1000000).toFixed(1) + 'M';
+  }
+  if (amount >= 1000) {
+    return '$' + Math.round(amount / 1000) + 'K';
+  }
+  return '$' + amount.toLocaleString();
+};
+
+/**
+ * Format odds to standard racing notation
+ *
+ * @param odds - Decimal odds value
+ * @param isFavorite - Whether to prefix with asterisk
+ * @returns Formatted odds string
+ */
+export const formatOdds = (odds: number | null | undefined, isFavorite?: boolean): string => {
+  if (odds === null || odds === undefined) return '—';
+  const prefix = isFavorite ? '*' : '';
+  if (odds < 1) {
+    // Odds-on favorite (e.g., 0.5 = 1-2)
+    return prefix + odds.toFixed(1);
+  }
+  if (odds < 10) {
+    return prefix + odds.toFixed(1);
+  }
+  return prefix + Math.round(odds).toString();
+};
+
+// Test function for verifying distance formatting (can be run in console)
+export const testDistanceFormatting = (): void => {
+  const testDistances = [
+    { furlongs: 4, expected: '4f' },
+    { furlongs: 4.5, expected: '4½f' },
+    { furlongs: 5, expected: '5f' },
+    { furlongs: 5.5, expected: '5½f' },
+    { furlongs: 6, expected: '6f' },
+    { furlongs: 6.5, expected: '6½f' },
+    { furlongs: 7, expected: '7f' },
+    { furlongs: 7.5, expected: '7½f' },
+    { furlongs: 8, expected: '1m' },
+    { furlongs: 8.5, expected: '1¹⁄₁₆m' },
+    { furlongs: 9, expected: '1⅛m' },
+    { furlongs: 9.5, expected: '1³⁄₁₆m' },
+    { furlongs: 10, expected: '1¼m' },
+    { furlongs: 11, expected: '1³⁄₈m' },
+    { furlongs: 12, expected: '1½m' },
+    { furlongs: 13, expected: '1⅝m' },
+    { furlongs: 14, expected: '1¾m' },
+    { furlongs: 16, expected: '2m' },
+  ];
+
+  console.log('=== Distance Formatting Test ===');
+  let passed = 0;
+  let failed = 0;
+
+  testDistances.forEach(({ furlongs, expected }) => {
+    const result = formatRacingDistance(furlongs);
+    const status = result === expected ? '✓' : '✗';
+    if (result === expected) {
+      passed++;
+    } else {
+      failed++;
+    }
+    console.log(`${furlongs}f => ${result} (expected: ${expected}) ${status}`);
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+};


### PR DESCRIPTION
- Create centralized formatRacingDistance utility in src/utils/formatters.ts
- Update PPLine.tsx to use new formatter for past performance distances
- Update HorseExpandedView.tsx to use new formatter for workout distances
- Add documentation comments to drfParser.ts for distance conversion

Racing industry standard now applied:
- Under 8 furlongs: show as furlongs (4f, 5½f, 6f, 6½f, 7f)
- 8 furlongs = 1 mile: show as "1m"
- Over 1 mile: show as miles with fractions (1¹⁄₁₆m, 1⅛m, 1¼m, etc.)

Fixes issue where short distances incorrectly showed "m" (miles) instead of "f" (furlongs) and decimal formats like "6.28m" appeared.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
