### PR TITLE
Fix distance formatter showing miles instead of furlongs

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -68,10 +68,14 @@ export const formatRacingDistance = (furlongs: number): string => {
     const whole = Math.floor(furlongs);
     const frac = furlongs - whole;
 
-    if (frac < 0.1) return `${whole}f`;
-    if (Math.abs(frac - 0.5) < 0.1) return `${whole}½f`;
-    if (Math.abs(frac - 0.25) < 0.1) return `${whole}¼f`;
-    if (Math.abs(frac - 0.75) < 0.1) return `${whole}¾f`;
+    if (frac < 0.05) return `${whole}f`;
+    if (Math.abs(frac - 0.125) < 0.05) return `${whole}⅛f`; // 1/8
+    if (Math.abs(frac - 0.25) < 0.05) return `${whole}¼f`; // 1/4
+    if (Math.abs(frac - 0.375) < 0.05) return `${whole}⅜f`; // 3/8
+    if (Math.abs(frac - 0.5) < 0.05) return `${whole}½f`; // 1/2
+    if (Math.abs(frac - 0.625) < 0.05) return `${whole}⅝f`; // 5/8
+    if (Math.abs(frac - 0.75) < 0.05) return `${whole}¾f`; // 3/4
+    if (Math.abs(frac - 0.875) < 0.05) return `${whole}⅞f`; // 7/8
 
     // For unusual fractions, show decimal
     return `${furlongs.toFixed(1)}f`;


### PR DESCRIPTION
Root cause: DRF files store PP distances in eighths of furlongs (e.g., 48 = 6f) but the parser was treating these values as actual furlongs. Values like 48 would exceed 8 and get formatted as miles (48/8 = 6m) instead of furlongs.

Changes:
- parseDistance now auto-detects format: values > 16 are divided by 8
- Added support for all 1/8 fraction variants in formatRacingDistance
- Updated tolerance for fraction matching to 0.05

The formatter now correctly displays:
- 6f, 6⅛f, 6¼f, 6½f for sprint distances (< 8f)
- 1m, 1⅛m, 1¼m for route distances (>= 8f)

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
