### PR TITLE
Add parsing for final time and days-since-last-race

### DIFF
--- a/src/components/HorseExpandedView.css
+++ b/src/components/HorseExpandedView.css
@@ -548,14 +548,32 @@
   text-align: center;
 }
 
+.horse-pp__col--time {
+  width: 52px;
+  min-width: 52px;
+  text-align: right;
+}
+
+.horse-pp__col--days {
+  width: 36px;
+  min-width: 36px;
+  text-align: center;
+}
+
+.horse-pp__col--em {
+  width: 40px;
+  min-width: 40px;
+  text-align: center;
+}
+
 .horse-pp__col--running {
-  width: 120px; /* Reduced from 140px */
-  min-width: 120px;
+  width: 110px; /* Reduced from 120px to fit new columns */
+  min-width: 110px;
 }
 
 .horse-pp__col--jockey {
-  width: 80px; /* Reduced from 90px */
-  min-width: 80px;
+  width: 75px; /* Reduced from 80px to fit new columns */
+  min-width: 75px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -568,7 +586,7 @@
 
 .horse-pp__col--comment {
   flex: 1;
-  min-width: 100px;
+  min-width: 80px; /* Reduced from 100px to fit new columns */
 }
 
 /* ============================================

--- a/src/components/HorseExpandedView.tsx
+++ b/src/components/HorseExpandedView.tsx
@@ -61,7 +61,7 @@ interface WorkoutItemProps {
   index: number;
 }
 
-const WorkoutItem: React.FC<WorkoutItemProps> = ({ workout, index }) => {
+const WorkoutItem: React.FC<WorkoutItemProps> = ({ workout, index: _index }) => {
   // Type-safe access with Record for flexible field access
   const w = workout as Workout & Record<string, unknown>;
 
@@ -135,17 +135,6 @@ const WorkoutItem: React.FC<WorkoutItemProps> = ({ workout, index }) => {
   // distanceFurlongs is calculated by parser (yards / 220)
   const getWorkoutDistance = (): string => {
     const furlongs = w.distanceFurlongs;
-
-    // DIAGNOSTIC TRACE - First workout only
-    if (index === 0) {
-      console.log('===== WORKOUT COMPONENT TRACE (First Workout) =====');
-      console.log('workout object:', workout);
-      console.log('workout.distanceFurlongs:', workout.distanceFurlongs);
-      console.log('workout.distance:', workout.distance);
-      console.log('typeof distanceFurlongs:', typeof workout.distanceFurlongs);
-      console.log('w.distanceFurlongs (from Record):', w.distanceFurlongs);
-      console.log('====================================================');
-    }
 
     // Validate it's a reasonable workout distance (3f to 7f)
     // Workouts are rarely shorter than 3f or longer than 7f
@@ -667,6 +656,9 @@ export const HorseExpandedView: React.FC<HorseExpandedViewProps> = ({
             <span className="horse-pp__col horse-pp__col--finish">FIN</span>
             <span className="horse-pp__col horse-pp__col--odds">ODDS</span>
             <span className="horse-pp__col horse-pp__col--figure">FIG</span>
+            <span className="horse-pp__col horse-pp__col--time">TIME</span>
+            <span className="horse-pp__col horse-pp__col--days">DAYS</span>
+            <span className="horse-pp__col horse-pp__col--em">E/M</span>
             <span className="horse-pp__col horse-pp__col--running">RUNNING LINE</span>
             <span className="horse-pp__col horse-pp__col--jockey">JOCKEY</span>
             <span className="horse-pp__col horse-pp__col--weight">WT</span>

--- a/src/components/PPLine.css
+++ b/src/components/PPLine.css
@@ -106,16 +106,39 @@
   color: #2563eb;
 }
 
+.pp-line__col--time {
+  width: 52px;
+  min-width: 52px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.pp-line__col--days {
+  width: 36px;
+  min-width: 36px;
+  text-align: center;
+  font-size: 9px;
+  color: #666;
+}
+
+.pp-line__col--em {
+  width: 40px;
+  min-width: 40px;
+  text-align: center;
+  font-size: 9px;
+  font-weight: 600;
+}
+
 .pp-line__col--running {
-  width: 120px; /* Reduced from 140px - match header */
-  min-width: 120px;
+  width: 110px; /* Reduced from 120px to fit new columns */
+  min-width: 110px;
   font-size: 9px; /* Reduced from 10px */
   letter-spacing: -0.02em;
 }
 
 .pp-line__col--jockey {
-  width: 80px; /* Reduced from 90px - match header */
-  min-width: 80px;
+  width: 75px; /* Reduced from 80px to fit new columns */
+  min-width: 75px;
   font-size: 9px; /* Reduced from 10px */
 }
 
@@ -128,8 +151,8 @@
 
 .pp-line__col--comment {
   flex: 1;
-  min-width: 150px; /* Increased from 100px */
-  max-width: 250px; /* Add max to prevent too wide */
+  min-width: 80px; /* Reduced from 150px to fit new columns */
+  max-width: 200px; /* Reduced from 250px */
   font-size: 9px;
   font-style: italic;
   color: #666;

--- a/src/components/PPLine.tsx
+++ b/src/components/PPLine.tsx
@@ -9,18 +9,6 @@ interface PPLineProps {
 }
 
 export const PPLine: React.FC<PPLineProps> = ({ pp, index }) => {
-  // TEMPORARY DEBUG - Remove after diagnostic
-  if (index === 0) {
-    console.log('PP Object - All Fields:', Object.keys(pp));
-    console.log('PP Object - Full Data:', JSON.stringify(pp, null, 2).slice(0, 2000));
-    console.log('PP Target Fields:', {
-      finalTime: pp.finalTime,
-      finalTimeFormatted: pp.finalTimeFormatted,
-      daysSinceLast: pp.daysSinceLast,
-      equipment: pp.equipment,
-      medication: pp.medication,
-    });
-  }
   // Format date using industry standard: "9Aug25" (day + 3-letter month + 2-digit year)
   const formatDate = (dateStr: string | number | undefined): string => {
     if (!dateStr) return '—';
@@ -312,6 +300,36 @@ export const PPLine: React.FC<PPLineProps> = ({ pp, index }) => {
     return cleaned.slice(0, 50) || '—'; // Increased from 30
   };
 
+  // Format final time for display
+  const formatTime = (time: number | null, formatted?: string): string => {
+    if (formatted && formatted.trim()) return formatted;
+    if (!time || time <= 0) return '—';
+
+    const mins = Math.floor(time / 60);
+    const secs = (time % 60).toFixed(2);
+
+    if (mins === 0) {
+      return `:${secs}`;
+    }
+    return `${mins}:${secs.padStart(5, '0')}`;
+  };
+
+  // Format days since last race
+  const formatDays = (days: number | null | undefined): string => {
+    if (days === null || days === undefined || days <= 0) return '—';
+    return `${days}`;
+  };
+
+  // Format equipment/medication combined
+  const formatEM = (equip?: string, med?: string): string => {
+    const e = equip?.trim() || '';
+    const m = med?.trim() || '';
+
+    if (!e && !m) return '—';
+    if (e && m) return `${e}/${m}`;
+    return e || m;
+  };
+
   const isEven = index % 2 === 0;
 
   return (
@@ -334,6 +352,11 @@ export const PPLine: React.FC<PPLineProps> = ({ pp, index }) => {
         {formatOdds(pp.odds, pp.favoriteRank)}
       </span>
       <span className="pp-line__col pp-line__col--figure">{pp.speedFigures?.beyer ?? '—'}</span>
+      <span className="pp-line__col pp-line__col--time">
+        {formatTime(pp.finalTime, pp.finalTimeFormatted)}
+      </span>
+      <span className="pp-line__col pp-line__col--days">{formatDays(pp.daysSinceLast)}</span>
+      <span className="pp-line__col pp-line__col--em">{formatEM(pp.equipment, pp.medication)}</span>
       <span className="pp-line__col pp-line__col--running">
         {formatRunningLine(pp.runningLine)}
       </span>

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -21,15 +21,7 @@
  * @returns Formatted distance string (e.g., "6f", "1⅛m")
  */
 export const formatRacingDistance = (furlongs: number): string => {
-  // DIAGNOSTIC TRACE
-  console.log('===== FORMATTER TRACE =====');
-  console.log('Input furlongs:', furlongs);
-  console.log('Type:', typeof furlongs);
-  console.log('Is < 8?:', furlongs < 8);
-
   if (!furlongs || isNaN(furlongs) || furlongs <= 0) {
-    console.log('Returning (invalid input): —');
-    console.log('===========================');
     return '—';
   }
 
@@ -68,8 +60,6 @@ export const formatRacingDistance = (furlongs: number): string => {
   // Round to nearest standard distance (within 0.15 tolerance for parsing variance)
   for (const [standard, display] of Object.entries(standardDistances)) {
     if (Math.abs(furlongs - Number(standard)) < 0.15) {
-      console.log('Returning (standard match):', display);
-      console.log('===========================');
       return display;
     }
   }
@@ -98,8 +88,6 @@ export const formatRacingDistance = (furlongs: number): string => {
       result = `${whole}⅞f`; // 7/8
     else result = `${furlongs.toFixed(1)}f`; // For unusual fractions, show decimal
 
-    console.log('Returning (manual furlong calc):', result, '(whole:', whole, ', frac:', frac, ')');
-    console.log('===========================');
     return result;
   } else {
     // Show as miles for route distances (8+ furlongs)
@@ -131,18 +119,6 @@ export const formatRacingDistance = (furlongs: number): string => {
       result = `${whole}⅞m`; // 7/8
     else result = `${miles.toFixed(2)}m`; // For unusual fractions, show decimal miles
 
-    console.log(
-      'Returning (manual mile calc):',
-      result,
-      '(miles:',
-      miles,
-      ', whole:',
-      whole,
-      ', frac:',
-      frac,
-      ')'
-    );
-    console.log('===========================');
     return result;
   }
 };


### PR DESCRIPTION
- parse final time from DRF field index 1005 in parsePastPerformances
- calculate days since last race by comparing consecutive PP dates
- add TIME, DAYS, E/M columns to PP header and PP lines
- add formatting helpers for time (MM:SS.XX), days, and E/M display
- update CSS for new columns with proper widths and alignment
- remove diagnostic console.log statements from parser and components

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
