### PR TITLE
fix(betting): include MEDIUM confidence horses in exacta/trifecta boxes

### DIFF
--- a/src/lib/betting/tierClassification.ts
+++ b/src/lib/betting/tierClassification.ts
@@ -20,7 +20,7 @@ export interface TierThresholds {
 export const TIER_CONFIG: Record<BettingTier, TierThresholds> = {
   tier1: { minScore: 180, maxScore: 240, minConfidence: 80, maxConfidence: 100 },
   tier2: { minScore: 160, maxScore: 179, minConfidence: 60, maxConfidence: 79 },
-  tier3: { minScore: 140, maxScore: 159, minConfidence: 40, maxConfidence: 59 },
+  tier3: { minScore: 130, maxScore: 159, minConfidence: 40, maxConfidence: 59 },
 };
 
 export const TIER_NAMES: Record<BettingTier, string> = {

--- a/src/lib/recommendations/betGenerator.ts
+++ b/src/lib/recommendations/betGenerator.ts
@@ -186,20 +186,21 @@ function generateTier1Bets(
     })
   );
 
-  // 3. Exacta box (top 2-3 horses in tier)
-  if (horses.length >= 2) {
-    const boxHorses = horses.slice(0, Math.min(3, horses.length));
+  // 3. Exacta box (top 2-3 horses across ALL tiers - includes MEDIUM confidence)
+  // Use allClassifiedHorses to include tier 2/3 horses that statistically hit top 2
+  const exactaBoxHorses = allClassifiedHorses.slice(0, Math.min(3, allClassifiedHorses.length));
+  if (exactaBoxHorses.length >= 2) {
     const boxAmount = Math.round(baseAmount / 2);
     bets.push(
       createGeneratedBet({
         type: 'exacta_box',
         typeName: 'Exacta Box',
-        description: `Exacta box with top ${boxHorses.length} contenders`,
-        horses: boxHorses,
+        description: `Exacta box with top ${exactaBoxHorses.length} contenders`,
+        horses: exactaBoxHorses,
         amount: boxAmount,
         tier: 'tier1',
         raceNumber,
-        confidence: averageConfidence(boxHorses),
+        confidence: averageConfidence(exactaBoxHorses),
         icon: 'swap_vert',
       })
     );
@@ -227,41 +228,23 @@ function generateTier1Bets(
     );
   }
 
-  // 5. Trifecta box (top 3 if applicable)
-  if (horses.length >= 3) {
-    const triHorses = horses.slice(0, 3);
+  // 5. Trifecta box (top 3 across ALL tiers - includes MEDIUM confidence)
+  // Use allClassifiedHorses to include tier 2/3 horses that statistically hit top 3
+  const trifectaBoxHorses = allClassifiedHorses.slice(0, 3);
+  if (trifectaBoxHorses.length >= 3) {
     bets.push(
       createGeneratedBet({
         type: 'trifecta_box',
         typeName: 'Trifecta Box',
-        description: 'Trifecta box with top 3 chalk',
-        horses: triHorses,
+        description: 'Trifecta box with top 3 contenders',
+        horses: trifectaBoxHorses,
         amount: 1,
         tier: 'tier1',
         raceNumber,
-        confidence: averageConfidence(triHorses) - 15,
+        confidence: averageConfidence(trifectaBoxHorses) - 15,
         icon: 'view_list',
       })
     );
-  } else if (horses.length >= 2) {
-    // Use tier 1 + next best horse for trifecta
-    const nextBest = allClassifiedHorses.find((h) => !horses.includes(h));
-    if (nextBest && horses[0] && horses[1]) {
-      const triHorses = [horses[0], horses[1], nextBest];
-      bets.push(
-        createGeneratedBet({
-          type: 'trifecta_box',
-          typeName: 'Trifecta Box',
-          description: 'Trifecta box: chalk with one alternative',
-          horses: triHorses,
-          amount: 1,
-          tier: 'tier1',
-          raceNumber,
-          confidence: 55,
-          icon: 'view_list',
-        })
-      );
-    }
   }
 
   return bets;


### PR DESCRIPTION
- Lower tier 3 minimum score from 140 to 130 to align with MEDIUM confidence threshold (score 130+)
- Update exacta box to use top 3 horses from ALL tiers (not just tier 1)
- Update trifecta box to use top 3 horses from ALL tiers
- Based on race analysis showing 100% of winners were MEDIUM+ confidence and 41% of winners were MEDIUM

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
