### PR TITLE
refactor(ui): replace odds stepper with click-to-edit input

### DIFF
--- a/src/components/HorseSummaryBar.css
+++ b/src/components/HorseSummaryBar.css
@@ -161,68 +161,68 @@
   white-space: nowrap;
 }
 
-/* Live odds with stepper */
+/* Live odds - click to edit */
 .horse-summary-bar__odds {
   font-size: 14px;
   font-weight: 600;
   color: var(--color-text-primary);
   text-align: center;
-}
-
-/* Inline odds stepper */
-.odds-stepper-inline {
-  display: inline-flex;
-  align-items: center;
-  gap: 0;
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 6px;
-  padding: 2px;
-}
-
-.odds-stepper-inline__btn {
   display: flex;
-  align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  align-items: center;
+}
+
+/* Editable odds value button */
+.odds-edit-value {
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--color-primary, #19abb5);
   background: transparent;
   border: none;
-  border-radius: 4px;
-  color: rgba(255, 255, 255, 0.6);
+  border-bottom: 1px dashed rgba(25, 171, 181, 0.5);
+  padding: 4px 8px;
   cursor: pointer;
   transition: all 0.15s ease;
-  padding: 0;
+  min-width: 48px;
+  text-align: center;
 }
 
-.odds-stepper-inline__btn .material-icons {
-  font-size: 16px;
+.odds-edit-value:hover:not(:disabled) {
+  border-bottom-color: var(--color-primary, #19abb5);
+  background: rgba(25, 171, 181, 0.1);
 }
 
-.odds-stepper-inline__btn:hover:not(:disabled) {
-  background: rgba(25, 171, 181, 0.25);
-  color: var(--color-primary, #19abb5);
+.odds-edit-value:focus {
+  outline: none;
+  border-bottom-style: solid;
+  border-bottom-color: var(--color-primary, #19abb5);
 }
 
-.odds-stepper-inline__btn:active:not(:disabled) {
-  background: rgba(25, 171, 181, 0.35);
-  transform: scale(0.95);
-}
-
-.odds-stepper-inline__btn:disabled {
-  color: rgba(255, 255, 255, 0.2);
+.odds-edit-value--disabled {
+  color: var(--color-text-tertiary);
+  border-bottom-color: transparent;
   cursor: not-allowed;
 }
 
-.odds-stepper-inline__value {
-  min-width: 40px;
-  padding: 0 6px;
-  font-size: 13px;
+/* Odds edit input */
+.odds-edit-input {
+  font-size: 14px;
   font-weight: 600;
+  font-family: inherit;
   color: var(--color-primary, #19abb5);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--color-primary, #19abb5);
+  border-radius: 4px;
+  padding: 4px 8px;
+  width: 64px;
   text-align: center;
-  border-left: 1px solid rgba(255, 255, 255, 0.1);
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  outline: none;
+}
+
+.odds-edit-input::placeholder {
+  color: var(--color-text-tertiary);
+  font-weight: 400;
 }
 
 /* Score - right aligned */


### PR DESCRIPTION
Replace the +/- stepper buttons with a simpler click-to-edit pattern for changing horse odds. Users can now:

- Click on odds to enter edit mode
- Type odds in flexible formats (7-2, 7/2, 7:2, or just 7 for 7-1)
- Press Enter to save or Escape to cancel
- Blur to auto-save

This provides a more intuitive UX than stepping through a 31-value sequence. The dashed underline indicates editability at a glance.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
