### PR TITLE
Add pace figures parsing for scoring

### DIFF
--- a/src/types/drf.ts
+++ b/src/types/drf.ts
@@ -240,6 +240,10 @@ export interface PastPerformance {
   claimedFrom: string | null;
   /** Days since previous race */
   daysSinceLast: number | null;
+  /** Early Pace 1 (EP1) figure - rating at first call (DRF Fields 816-825) */
+  earlyPace1: number | null;
+  /** Late Pace figure - closing ability rating (DRF Fields 846-855) */
+  latePace: number | null;
 }
 
 // ============================================================================


### PR DESCRIPTION
Parse DRF Fields 816-825 (Early Pace 1) and 846-855 (Late Pace) and make them available in PastPerformance records for pace analysis scoring.

- Add earlyPace1 and latePace fields to PastPerformance interface
- Implement parsePaceFigure() with validation (0-150 range with warnings)
- Handle missing/empty values (returns null) and invalid values (returns 0)
- Add 9 comprehensive tests covering all edge cases

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
