### PR TITLE
Integrate trainer stats and scoring

### DIFF
--- a/src/lib/patterns/__tests__/connectionSynergy.test.ts
+++ b/src/lib/patterns/__tests__/connectionSynergy.test.ts
@@ -9,14 +9,15 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type {
-  HorseEntry,
-  PastPerformance,
-  SpeedFigures,
-  RunningLine,
-  Equipment,
-  Medication,
-  Breeding,
+import {
+  createDefaultTrainerCategoryStats,
+  type HorseEntry,
+  type PastPerformance,
+  type SpeedFigures,
+  type RunningLine,
+  type Equipment,
+  type Medication,
+  type Breeding,
 } from '../../../types/drf';
 import {
   buildPartnershipDatabase,
@@ -166,6 +167,7 @@ function createMockHorse(overrides: Partial<HorseEntry> = {}): HorseEntry {
     trainerMeetWins: 0,
     trainerMeetPlaces: 0,
     trainerMeetShows: 0,
+    trainerCategoryStats: createDefaultTrainerCategoryStats(),
     jockeyStats: '',
     jockeyMeetStarts: 0,
     jockeyMeetWins: 0,

--- a/src/lib/patterns/__tests__/jockeyPatterns.test.ts
+++ b/src/lib/patterns/__tests__/jockeyPatterns.test.ts
@@ -11,15 +11,16 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type {
-  HorseEntry,
-  PastPerformance,
-  RaceHeader,
-  SpeedFigures,
-  RunningLine,
-  Equipment,
-  Medication,
-  Breeding,
+import {
+  createDefaultTrainerCategoryStats,
+  type HorseEntry,
+  type PastPerformance,
+  type RaceHeader,
+  type SpeedFigures,
+  type RunningLine,
+  type Equipment,
+  type Medication,
+  type Breeding,
 } from '../../../types/drf';
 import {
   normalizeJockeyName,
@@ -171,6 +172,7 @@ function createMockHorse(overrides: Partial<HorseEntry> = {}): HorseEntry {
     trainerMeetWins: 0,
     trainerMeetPlaces: 0,
     trainerMeetShows: 0,
+    trainerCategoryStats: createDefaultTrainerCategoryStats(),
     jockeyStats: '',
     jockeyMeetStarts: 0,
     jockeyMeetWins: 0,

--- a/src/lib/patterns/__tests__/trainerPatterns.test.ts
+++ b/src/lib/patterns/__tests__/trainerPatterns.test.ts
@@ -10,15 +10,16 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type {
-  HorseEntry,
-  PastPerformance,
-  RaceHeader,
-  SpeedFigures,
-  RunningLine,
-  Equipment,
-  Medication,
-  Breeding,
+import {
+  createDefaultTrainerCategoryStats,
+  type HorseEntry,
+  type PastPerformance,
+  type RaceHeader,
+  type SpeedFigures,
+  type RunningLine,
+  type Equipment,
+  type Medication,
+  type Breeding,
 } from '../../../types/drf';
 import {
   normalizeTrainerName,
@@ -168,6 +169,7 @@ function createMockHorse(overrides: Partial<HorseEntry> = {}): HorseEntry {
     trainerMeetWins: 0,
     trainerMeetPlaces: 0,
     trainerMeetShows: 0,
+    trainerCategoryStats: createDefaultTrainerCategoryStats(),
     jockeyStats: '',
     jockeyMeetStarts: 0,
     jockeyMeetWins: 0,

--- a/src/lib/recommendations/__tests__/betGenerator.test.ts
+++ b/src/lib/recommendations/__tests__/betGenerator.test.ts
@@ -101,6 +101,11 @@ function createMockScoreBreakdown(overrides: Partial<ScoreBreakdown> = {}): Scor
       distanceWinRate: 0,
       reasoning: ['No distance/surface bonus'],
     },
+    trainerPatterns: {
+      total: 0,
+      matchedPatterns: [],
+      reasoning: ['No trainer pattern bonus'],
+    },
     ...overrides,
   };
 }


### PR DESCRIPTION
Add required trainerCategoryStats field to mock horse entries in pattern test files and trainerPatterns to score breakdown mock in betGenerator test to fix TypeScript build errors.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
