### PR TITLE
Fix sparkline drop-off at rightmost point

### DIFF
--- a/src/components/TrendSparkline.tsx
+++ b/src/components/TrendSparkline.tsx
@@ -137,11 +137,8 @@ export function TrendSparkline({
         <LineChart data={chartData} margin={{ top: 2, right: 2, bottom: 2, left: 2 }}>
           <YAxis
             hide
-            domain={
-              invertYAxis
-                ? [maxValue + padding, Math.max(0, minValue - padding)] // Inverted for finish positions
-                : [Math.max(0, minValue - padding), maxValue + padding]
-            }
+            domain={[Math.max(0, minValue - padding), maxValue + padding]}
+            reversed={invertYAxis}
           />
           <Line
             type="monotone"


### PR DESCRIPTION
The sparkline was trying to invert the Y-axis for finish positions by swapping domain values [max, min], but Recharts doesn't properly support this approach. This caused finish positions to render incorrectly, with better finishes (lower numbers) appearing at the bottom of the graph.

Fix: Use the `reversed` prop on YAxis (matching TrendDetailModal) which properly inverts the axis so 1st place finishes appear at the top.

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
