### PR TITLE
fix: convert twinspires decimal odds to fractional format

### DIFF
--- a/src/services/twinspires/mapper.ts
+++ b/src/services/twinspires/mapper.ts
@@ -14,18 +14,48 @@ import type { TwinSpiresEntry } from './types';
 // ============================================================================
 
 /**
+ * Convert a TwinSpires odds value to standard fractional format (e.g. "5-2").
+ *
+ * The API returns odds as decimal ratios ("2.50" for 5/2, "3" for 3/1).
+ * US racing uses denominators 1, 2, and 5 — we try each in order.
+ */
+function normalizeLiveOdds(raw: string): string {
+  const trimmed = raw.trim();
+
+  // Already fractional with slash or dash (e.g. "5/2", "3-1") — just normalize separator
+  if (/^\d+-\d+$/.test(trimmed)) return trimmed;
+  if (/^\d+\/\d+$/.test(trimmed)) return trimmed.replace('/', '-');
+
+  // Numeric value — convert decimal ratio to fractional
+  const decimal = parseFloat(trimmed);
+  if (isNaN(decimal) || decimal <= 0) return trimmed;
+
+  // Try common US racing denominators: 1, 2, 5
+  for (const denom of [1, 2, 5]) {
+    const numer = decimal * denom;
+    if (Math.abs(numer - Math.round(numer)) < 0.01) {
+      return `${Math.round(numer)}-${denom}`;
+    }
+  }
+
+  // Fallback: treat as X-1
+  return `${Math.round(decimal)}-1`;
+}
+
+/**
  * Map TwinSpires entries to a programNumber -> liveOdds record.
  * Skips entries with null liveOdds.
+ * Converts decimal ratios to fractional format (e.g. 2.50 → "5-2").
  *
  * @param entries - Array of TwinSpires entries
- * @returns Record mapping programNumber string to liveOdds string
+ * @returns Record mapping programNumber string to fractional odds string
  */
 export function mapTwinSpiresEntriesToOdds(entries: TwinSpiresEntry[]): Record<string, string> {
   const oddsMap: Record<string, string> = {};
 
   for (const entry of entries) {
     if (entry.liveOdds !== null) {
-      oddsMap[entry.programNumber] = entry.liveOdds;
+      oddsMap[entry.programNumber] = normalizeLiveOdds(String(entry.liveOdds));
     }
   }
 


### PR DESCRIPTION
TwinSpires API returns odds as decimal ratios (e.g. "2.50" for 5/2, "3" for 3-1). The display code expected "X-Y" fractional format, so parseInt("2.50") produced "2-1" instead of "5-2". Now normalizes at ingestion time using standard US racing denominators (1, 2, 5).

https://claude.ai/code/session_01MopHiT5DbD8hmtJxhUzP8X

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] CI/CD or infrastructure change

## Related Issues

<!-- Link any related issues here using "Fixes #123" or "Relates to #456" -->

## Testing Checklist

- [ ] All existing tests pass (`npm run test`)
- [ ] New tests added for new functionality
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Build succeeds (`npm run build`)

## Manual Testing

<!-- Describe any manual testing you performed -->

- [ ] Tested on mobile viewport (375px)
- [ ] Tested on desktop viewport
- [ ] Tested offline functionality (if applicable)

## Screenshots

<!-- If this PR includes UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Additional Notes

<!-- Any additional context, considerations, or notes for reviewers -->

---

**Reviewer Checklist:**

- [ ] Code follows project conventions and design system
- [ ] No `console.log` statements in production code
- [ ] No TypeScript `any` types
- [ ] Error handling is appropriate
- [ ] Changes are within scope of the PR description
